### PR TITLE
feat: Add configurable token count display to context bar

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,9 @@ pub struct DisplayConfig {
 
     /// Show session cost and burn rate
     pub show_cost: bool,
+
+    /// Show token counts in context bar (e.g., "179k/1000k")
+    pub show_context_tokens: bool,
 }
 
 /// Context window configuration
@@ -354,6 +357,8 @@ impl Default for DisplayConfig {
             show_duration: true,
             show_lines_changed: true,
             show_cost: true,
+            // Token counts opt-in (new feature, default off for minimal statusline)
+            show_context_tokens: false,
         }
     }
 }
@@ -643,6 +648,18 @@ context_caution_threshold = 50.0     # Yellow color above this
 
 # Theme: "dark" or "light"
 theme = "dark"
+
+# Component visibility toggles (all default to true except show_context_tokens)
+# show_directory = true
+# show_git = true
+# show_context = true
+# show_model = true
+# show_duration = true
+# show_lines_changed = true
+# show_cost = true
+
+# Show token counts in context bar (e.g., "179k/1000k")
+# show_context_tokens = false
 
 [context]
 # Default context window size in tokens (modern Claude models use 200k)

--- a/src/display.rs
+++ b/src/display.rs
@@ -283,7 +283,13 @@ fn format_statusline_string(
         if let Some(transcript) = transcript_path {
             if let Some(context) = calculate_context_usage(transcript, model_name, session_id, None)
             {
-                parts.push(format_context_bar(&context));
+                let current_tokens = crate::utils::get_token_count_from_transcript(transcript);
+                let full_config = config::get_config();
+                let window_size = Some(crate::utils::get_context_window_for_model(
+                    model_name,
+                    full_config,
+                ));
+                parts.push(format_context_bar(&context, current_tokens, window_size));
             }
         }
     }
@@ -469,17 +475,43 @@ pub fn format_output_to_string(
     )
 }
 
-fn format_context_bar(context: &ContextUsage) -> String {
+fn format_context_bar(
+    context: &ContextUsage,
+    current_tokens: Option<u32>,
+    window_size: Option<usize>,
+) -> String {
     use crate::models::CompactionState;
 
     let config = config::get_config();
     let bar_width = config.display.progress_bar_width;
 
+    // Format token counts if enabled and data available
+    let token_display = if let (Some(current), Some(window)) = (current_tokens, window_size) {
+        if config.display.show_context_tokens {
+            format!(
+                " {}{}/{}{}",
+                Colors::light_gray(),
+                crate::utils::format_token_count(current as usize),
+                crate::utils::format_token_count(window),
+                Colors::reset()
+            )
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
     // Handle different compaction states
     match context.compaction_state {
         CompactionState::InProgress => {
             // Simple static indicator - statusline doesn't update frequently enough for animation
-            format!("{}Compacting...{}", Colors::yellow(), Colors::reset())
+            format!(
+                "{}Compacting...{}{}",
+                Colors::yellow(),
+                Colors::reset(),
+                token_display
+            )
         }
 
         CompactionState::RecentlyCompleted => {
@@ -501,7 +533,7 @@ fn format_context_bar(context: &ContextUsage) -> String {
             );
 
             format!(
-                "{}{}%{} {}[{}]{} {}✓{}",
+                "{}{}%{} {}[{}]{} {}✓{}{}",
                 percentage_color,
                 percentage.round() as u32,
                 Colors::reset(),
@@ -509,7 +541,8 @@ fn format_context_bar(context: &ContextUsage) -> String {
                 bar,
                 Colors::reset(),
                 Colors::green(),
-                Colors::reset()
+                Colors::reset(),
+                token_display
             )
         }
 
@@ -539,14 +572,15 @@ fn format_context_bar(context: &ContextUsage) -> String {
             };
 
             format!(
-                "{}{}%{} {}[{}]{}{}",
+                "{}{}%{} {}[{}]{}{}{}",
                 percentage_color,
                 percentage.round() as u32,
                 Colors::reset(),
                 color,
                 bar,
                 Colors::reset(),
-                warning
+                warning,
+                token_display
             )
         }
     }
@@ -620,7 +654,7 @@ mod tests {
             tokens_remaining: 180_000,
             compaction_state: CompactionState::Normal,
         };
-        let bar = format_context_bar(&low);
+        let bar = format_context_bar(&low, None, None);
         assert!(bar.contains("10%"));
         assert!(bar.contains("[=>"));
         assert!(!bar.contains('•'));
@@ -632,7 +666,7 @@ mod tests {
             tokens_remaining: 10_000,
             compaction_state: CompactionState::Normal,
         };
-        let bar = format_context_bar(&high);
+        let bar = format_context_bar(&high, None, None);
         assert!(bar.contains("95%"));
         assert!(!bar.contains('•'));
         assert!(bar.contains('⚠')); // Warning at 95%


### PR DESCRIPTION
## Summary
Adds a new configuration option to display actual token usage alongside the percentage in the context bar.

## Features
- **Configurable display**: New `show_context_tokens` option in `[display]` config section
- **Readable format**: Shows "223k/1000k" instead of raw token numbers
- **Smart defaults**: Disabled by default to keep statusline minimal
- **All states supported**: Works with normal, compacting, and post-compact states
- **Theme aware**: Uses consistent colors and respects NO_COLOR

## Example Output

With `show_context_tokens = true`:
```
~/myproject [main] • 75% [=====-----] 150k/200k • Sonnet • $3.50
~/myproject [main] • 95% [=========>] ⚠ 190k/200k • Sonnet • $3.50
~/myproject [main] • Compacting... 150k/200k • Sonnet • $3.50
~/myproject [main] • 45% [====>-----] ✓ 90k/200k • Sonnet • $3.50
```

## Configuration

Add to your `~/.config/claudia-statusline/config.toml`:
```toml
[display]
show_context_tokens = true
```

## Testing
- ✅ Unit tests for token formatting
- ✅ All existing tests pass
- ✅ Manually tested in Claude Code session
- ✅ Backward compatible (disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------