### PR TITLE
Fix statusline hang with non-blocking file lock

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -499,10 +499,10 @@ impl Default for RetryConfig {
     fn default() -> Self {
         RetryConfig {
             file_ops: RetrySettings {
-                max_attempts: 3,
-                initial_delay_ms: 100,
-                max_delay_ms: 5000,
-                backoff_factor: 2.0,
+                max_attempts: 5,
+                initial_delay_ms: 50,
+                max_delay_ms: 2000,
+                backoff_factor: 1.5,
             },
             db_ops: RetrySettings {
                 max_attempts: 5,
@@ -802,11 +802,11 @@ retention_days_monthly = 0      # Keep monthly aggregates for N days (0 = foreve
 buffer_lines = 50
 
 [retry.file_ops]
-# File operation retry settings
-max_attempts = 3
-initial_delay_ms = 100
-max_delay_ms = 5000
-backoff_factor = 2.0
+# File operation retry settings (tuned for concurrent access)
+max_attempts = 5
+initial_delay_ms = 50
+max_delay_ms = 2000
+backoff_factor = 1.5
 
 [retry.db_ops]
 # Database operation retry settings

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -198,9 +198,15 @@ where
         }
     }
 
-    // All attempts failed, return the last error
-    Err(last_error
-        .unwrap_or_else(|| StatuslineError::other("Retry failed with no error information")))
+    // All attempts failed, log and return the last error
+    let final_error = last_error
+        .unwrap_or_else(|| StatuslineError::other("Retry failed with no error information"));
+    log::warn!(
+        "All {} retry attempts exhausted: {}",
+        config.max_attempts,
+        final_error
+    );
+    Err(final_error)
 }
 
 #[cfg(test)]

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -2,6 +2,7 @@
 //!
 //! Ensures that once-fixed bugs stay fixed.
 
+use serial_test::serial;
 use statusline::display::format_output_to_string;
 use statusline::models::ModelType;
 
@@ -129,9 +130,11 @@ fn test_git_info_no_leading_space() {
 // ============================================================================
 
 #[test]
+#[serial]
 fn test_no_color_environment_variable() {
     // Test that NO_COLOR is properly checked
     // Note: Due to theme caching, we just verify that Colors::enabled() respects NO_COLOR
+    // Must be #[serial] to prevent race conditions with other tests modifying env vars
     use statusline::display::Colors;
 
     // Save original state


### PR DESCRIPTION
- Use try_lock_exclusive() instead of lock_exclusive() to prevent indefinite blocking when multiple Claude instances run simultaneously
- Add explicit WouldBlock handling with debug logging for retries
- Log warn level for hard failures and when all retries exhausted
- Distinct error messages for transient vs permanent lock failures