### PR TITLE
Add PostCompact hook handler via SessionStart[compact]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PostCompact hook handler**: New `statusline hook postcompact` command for proper post-compaction cleanup
+  - Triggered via Claude Code's `SessionStart` hook with matcher `"compact"`
+  - Clears compaction state file created by PreCompact
+  - Resets `max_tokens_observed` to prevent Phase 2 false positives
+  - Fixes long-standing "Compacting..." persistence bug after auto-compact events
+
+### Changed
+
+- **Hook configuration**: Updated recommended hook setup to use `SessionStart[compact]` instead of `Stop`
+  - `Stop` hook fires after EVERY agent response (wrong for post-compaction cleanup)
+  - `SessionStart[compact]` fires exactly once when compaction completes
+
+### Fixed
+
+- **Compaction cleanup**: "Compacting..." no longer persists after compaction completes
+  - Root cause: Claude Code doesn't have a dedicated `PostCompact` hook
+  - Discovery: `SessionStart` with matcher `"compact"` IS the post-compaction hook
+  - Previous workaround using `Stop` hook was incorrect (fired too frequently)
+
 ## [2.21.1] - 2025-11-29
 
 ### Fixed

--- a/src/database.rs
+++ b/src/database.rs
@@ -941,6 +941,23 @@ impl SqliteDatabase {
         Ok(())
     }
 
+    /// Reset max_tokens_observed for ALL sessions
+    ///
+    /// Workaround for Claude Code bug #9567 where hooks receive empty session_id.
+    /// Since only one session compacts at a time, resetting all is safe.
+    /// The tracking will rebuild on the next statusline call.
+    ///
+    /// Returns the number of sessions affected.
+    pub fn reset_all_sessions_max_tokens(&self) -> Result<usize> {
+        let conn = self.get_connection()?;
+        let rows_affected = conn.execute("UPDATE sessions SET max_tokens_observed = 0", [])?;
+        log::info!(
+            "Reset max_tokens_observed to 0 for all {} sessions (empty session_id workaround)",
+            rows_affected
+        );
+        Ok(rows_affected)
+    }
+
     /// Get token breakdown for a session
     ///
     /// Returns (input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -43,8 +43,11 @@ pub fn handle_precompact(session_id: &str, trigger: &str) -> Result<()> {
 
 /// Handle Stop hook event
 ///
-/// Called when Claude session ends or compaction completes.
-/// Clears compaction state file so statusline shows normal state.
+/// Called after each Claude agent response (fires frequently).
+/// Only clears compaction state file - does NOT reset database.
+///
+/// NOTE: Stop hook fires after EVERY agent response, not just after compaction.
+/// For post-compaction cleanup, use handle_postcompact() instead.
 ///
 /// # Arguments
 ///
@@ -57,6 +60,64 @@ pub fn handle_stop(session_id: &str) -> Result<()> {
     clear_state(session_id)?;
 
     log::info!("Stop hook: session={}", session_id);
+
+    Ok(())
+}
+
+/// Handle PostCompact hook event (via SessionStart[compact])
+///
+/// Called after compaction completes. This is triggered by configuring
+/// a SessionStart hook with matcher "compact" in Claude Code settings.
+///
+/// This handler:
+/// 1. Clears the "compacting" state file created by PreCompact
+/// 2. Resets max_tokens_observed so Phase 2 detection starts fresh
+///
+/// # Arguments
+///
+/// * `session_id` - Current Claude session ID
+///
+/// # Returns
+///
+/// Ok(()) on success, error on cleanup failure
+///
+/// # Example Configuration
+///
+/// ```json
+/// {
+///   "hooks": {
+///     "SessionStart": [{
+///       "matcher": "compact",
+///       "hooks": [{"type": "command", "command": "statusline hook postcompact"}]
+///     }]
+///   }
+/// }
+/// ```
+pub fn handle_postcompact(session_id: &str) -> Result<()> {
+    use crate::common::get_data_dir;
+    use crate::database::SqliteDatabase;
+
+    // Clear the "compacting" state file created by PreCompact hook
+    clear_state(session_id)?;
+
+    // Reset max_tokens_observed for this session
+    // This ensures Phase 2 heuristic detection starts fresh
+    // and won't give false positives from pre-compaction token counts
+    let db_path = get_data_dir().join("stats.db");
+    if db_path.exists() {
+        if let Ok(db) = SqliteDatabase::new(&db_path) {
+            if let Err(e) = db.reset_session_max_tokens(session_id) {
+                log::warn!("Failed to reset max_tokens after compaction: {}", e);
+            } else {
+                log::debug!("Reset max_tokens_observed for session {}", session_id);
+            }
+        }
+    }
+
+    log::info!(
+        "PostCompact hook (via SessionStart[compact]): session={}",
+        session_id
+    );
 
     Ok(())
 }
@@ -143,5 +204,63 @@ mod tests {
         // Stop without precompact should not error (idempotent)
         let result = handle_stop(&session_id);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_handle_postcompact() {
+        let session_id = format!("{}-postcompact", test_session_id());
+
+        // Create compacting state first (simulates PreCompact)
+        handle_precompact(&session_id, "auto").unwrap();
+        assert!(read_state(&session_id).is_some());
+
+        // Handle postcompact (simulates SessionStart[compact])
+        handle_postcompact(&session_id).unwrap();
+
+        // Verify state was cleared
+        assert!(read_state(&session_id).is_none());
+    }
+
+    #[test]
+    fn test_postcompact_without_precompact() {
+        let session_id = format!("{}-no-precompact-post", test_session_id());
+
+        // PostCompact without PreCompact should not error (idempotent)
+        let result = handle_postcompact(&session_id);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_full_compaction_flow() {
+        let session_id = format!("{}-full-flow", test_session_id());
+
+        // 1. PreCompact: Compaction starts
+        handle_precompact(&session_id, "auto").unwrap();
+        let state = read_state(&session_id).expect("State should exist after PreCompact");
+        assert_eq!(state.state, "compacting");
+        assert_eq!(state.trigger, "auto");
+
+        // 2. PostCompact: Compaction ends (via SessionStart[compact])
+        handle_postcompact(&session_id).unwrap();
+
+        // 3. Verify clean state
+        assert!(
+            read_state(&session_id).is_none(),
+            "State should be cleared after PostCompact"
+        );
+    }
+
+    #[test]
+    fn test_postcompact_manual_trigger() {
+        let session_id = format!("{}-postcompact-manual", test_session_id());
+
+        // Create compacting state with manual trigger
+        handle_precompact(&session_id, "manual").unwrap();
+        let state = read_state(&session_id).expect("State should exist");
+        assert_eq!(state.trigger, "manual");
+
+        // PostCompact clears regardless of trigger type
+        handle_postcompact(&session_id).unwrap();
+        assert!(read_state(&session_id).is_none());
     }
 }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -100,16 +100,28 @@ pub fn handle_postcompact(session_id: &str) -> Result<()> {
     // Clear the "compacting" state file created by PreCompact hook
     clear_state(session_id)?;
 
-    // Reset max_tokens_observed for this session
-    // This ensures Phase 2 heuristic detection starts fresh
-    // and won't give false positives from pre-compaction token counts
+    // Reset max_tokens_observed to prevent Phase 2 false positives
+    // This ensures heuristic detection starts fresh after compaction
     let db_path = get_data_dir().join("stats.db");
     if db_path.exists() {
         if let Ok(db) = SqliteDatabase::new(&db_path) {
-            if let Err(e) = db.reset_session_max_tokens(session_id) {
-                log::warn!("Failed to reset max_tokens after compaction: {}", e);
+            if session_id.is_empty() {
+                // Workaround for Claude Code bug #9567: hooks receive empty session_id
+                // Since only one session compacts at a time, reset all sessions
+                match db.reset_all_sessions_max_tokens() {
+                    Ok(count) => log::info!(
+                        "Reset max_tokens for {} sessions (empty session_id workaround)",
+                        count
+                    ),
+                    Err(e) => log::warn!("Failed to reset all max_tokens: {}", e),
+                }
             } else {
-                log::debug!("Reset max_tokens_observed for session {}", session_id);
+                // Normal case: reset specific session
+                if let Err(e) = db.reset_session_max_tokens(session_id) {
+                    log::warn!("Failed to reset max_tokens after compaction: {}", e);
+                } else {
+                    log::debug!("Reset max_tokens_observed for session {}", session_id);
+                }
             }
         }
     }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -97,17 +97,18 @@ pub fn handle_postcompact(session_id: &str) -> Result<()> {
     use crate::common::get_data_dir;
     use crate::database::SqliteDatabase;
 
-    // Clear the "compacting" state file created by PreCompact hook
-    clear_state(session_id)?;
+    // Handle empty session_id specially (Claude Code bug #9567)
+    if session_id.is_empty() {
+        log::info!("PostCompact received empty session_id (Claude Code bug #9567 workaround)");
 
-    // Reset max_tokens_observed to prevent Phase 2 false positives
-    // This ensures heuristic detection starts fresh after compaction
-    let db_path = get_data_dir().join("stats.db");
-    if db_path.exists() {
-        if let Ok(db) = SqliteDatabase::new(&db_path) {
-            if session_id.is_empty() {
-                // Workaround for Claude Code bug #9567: hooks receive empty session_id
-                // Since only one session compacts at a time, reset all sessions
+        // Try to clear state-.json if it exists (PreCompact may have created it with empty ID)
+        // Ignore errors since the file might not exist
+        let _ = clear_state_file_directly("");
+
+        // Reset ALL sessions' max_tokens since we don't know which session compacted
+        let db_path = get_data_dir().join("stats.db");
+        if db_path.exists() {
+            if let Ok(db) = SqliteDatabase::new(&db_path) {
                 match db.reset_all_sessions_max_tokens() {
                     Ok(count) => log::info!(
                         "Reset max_tokens for {} sessions (empty session_id workaround)",
@@ -115,13 +116,24 @@ pub fn handle_postcompact(session_id: &str) -> Result<()> {
                     ),
                     Err(e) => log::warn!("Failed to reset all max_tokens: {}", e),
                 }
+            }
+        }
+
+        log::info!("PostCompact hook (via SessionStart[compact]): session=<empty>");
+        return Ok(());
+    }
+
+    // Normal case: clear state file for specific session
+    clear_state(session_id)?;
+
+    // Reset max_tokens_observed to prevent Phase 2 false positives
+    let db_path = get_data_dir().join("stats.db");
+    if db_path.exists() {
+        if let Ok(db) = SqliteDatabase::new(&db_path) {
+            if let Err(e) = db.reset_session_max_tokens(session_id) {
+                log::warn!("Failed to reset max_tokens after compaction: {}", e);
             } else {
-                // Normal case: reset specific session
-                if let Err(e) = db.reset_session_max_tokens(session_id) {
-                    log::warn!("Failed to reset max_tokens after compaction: {}", e);
-                } else {
-                    log::debug!("Reset max_tokens_observed for session {}", session_id);
-                }
+                log::debug!("Reset max_tokens_observed for session {}", session_id);
             }
         }
     }
@@ -131,6 +143,19 @@ pub fn handle_postcompact(session_id: &str) -> Result<()> {
         session_id
     );
 
+    Ok(())
+}
+
+/// Clear state file directly without validation (for empty session_id workaround)
+fn clear_state_file_directly(session_id: &str) -> Result<()> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or_else(|| crate::error::StatuslineError::Config("Cannot determine cache directory".to_string()))?
+        .join("claudia-statusline");
+    let state_file = cache_dir.join(format!("state-{}.json", session_id));
+    if state_file.exists() {
+        std::fs::remove_file(&state_file)?;
+        log::debug!("Removed state file: {:?}", state_file);
+    }
     Ok(())
 }
 

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -149,7 +149,9 @@ pub fn handle_postcompact(session_id: &str) -> Result<()> {
 /// Clear state file directly without validation (for empty session_id workaround)
 fn clear_state_file_directly(session_id: &str) -> Result<()> {
     let cache_dir = dirs::cache_dir()
-        .ok_or_else(|| crate::error::StatuslineError::Config("Cannot determine cache directory".to_string()))?
+        .ok_or_else(|| {
+            crate::error::StatuslineError::Config("Cannot determine cache directory".to_string())
+        })?
         .join("claudia-statusline");
     let state_file = cache_dir.join(format!("state-{}.json", session_id));
     if state_file.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,18 @@ enum HookAction {
         #[arg(long)]
         session_id: Option<String>,
     },
+
+    /// PostCompact hook - called after compaction completes (via SessionStart[compact])
+    ///
+    /// Configure in Claude Code settings with SessionStart hook and matcher "compact":
+    /// ```json
+    /// "SessionStart": [{"matcher": "compact", "hooks": [{"type": "command", "command": "statusline hook postcompact"}]}]
+    /// ```
+    Postcompact {
+        /// Session ID from Claude (if not provided, reads from stdin JSON)
+        #[arg(long)]
+        session_id: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -1624,6 +1636,18 @@ fn handle_hook_command(action: HookAction) -> Result<()> {
 
             hook_handler::handle_stop(&sid)?;
             println!("Stop hook processed for session: {}", sid);
+        }
+        HookAction::Postcompact { session_id } => {
+            // If CLI arg provided, use it; otherwise read from stdin
+            let sid = if let Some(s) = session_id {
+                s
+            } else {
+                let (s, _) = read_hook_json_from_stdin()?;
+                s
+            };
+
+            hook_handler::handle_postcompact(&sid)?;
+            println!("PostCompact hook processed for session: {}", sid);
         }
     }
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -358,15 +358,14 @@ pub fn get_token_breakdown_from_transcript(
     };
 
     // Process all assistant messages:
-    // - MAX for context-related tokens (input, cache_read) - represents peak context usage
+    // - LAST for context-related tokens (input, cache_read) - represents CURRENT context usage
+    //   This is what users see on the statusline (e.g., "9%" after compaction, not "64%")
     // - SUM for generated tokens (output, cache_creation) - represents total work done
     //
-    // This distinction is critical for accurate token rate calculation:
-    // - Context tokens (input/cache_read) grow with conversation length, MAX shows peak
-    // - Generated tokens (output) are per-message, SUM shows total output across session
-    let mut max_context_total = 0u32;
-    let mut max_input = 0u32;
-    let mut max_cache_read = 0u32;
+    // IMPORTANT: For compaction detection heuristics (Phase 2), the database tracks
+    // max_tokens_observed separately. This function returns CURRENT values for display.
+    let mut last_input = 0u32;
+    let mut last_cache_read = 0u32;
     let mut sum_output = 0u32;
     let mut sum_cache_creation = 0u32;
     let mut has_data = false;
@@ -387,13 +386,11 @@ pub fn get_token_breakdown_from_transcript(
                     sum_output = sum_output.saturating_add(output);
                     sum_cache_creation = sum_cache_creation.saturating_add(cache_creation);
 
-                    // MAX: input and cache_read (peak context usage for context window tracking)
-                    let context_total = input + cache_read;
-                    if context_total > max_context_total {
-                        max_context_total = context_total;
-                        max_input = input;
-                        max_cache_read = cache_read;
-                    }
+                    // LAST: input and cache_read (CURRENT context usage for display)
+                    // We overwrite on each iteration to keep only the most recent values
+                    // This ensures the statusline shows current context %, not historical peak
+                    last_input = input;
+                    last_cache_read = cache_read;
                 }
             }
         }
@@ -401,9 +398,9 @@ pub fn get_token_breakdown_from_transcript(
 
     if has_data {
         Some(TokenBreakdown {
-            input_tokens: max_input,
+            input_tokens: last_input,
             output_tokens: sum_output,
-            cache_read_tokens: max_cache_read,
+            cache_read_tokens: last_cache_read,
             cache_creation_tokens: sum_cache_creation,
         })
     } else {

--- a/tests/hook_integration_tests.rs
+++ b/tests/hook_integration_tests.rs
@@ -557,3 +557,73 @@ fn test_postcompact_idempotency() {
         );
     }
 }
+
+#[test]
+fn test_postcompact_with_empty_session_id() {
+    // Test workaround for Claude Code bug #9567: hooks receive empty session_id
+    // PostCompact should succeed and reset ALL sessions' max_tokens
+    //
+    // Note: Claude Code sends empty session_id via stdin JSON, not CLI args.
+    // The CLI validates non-empty session_id, but stdin JSON bypasses this.
+    let binary = get_test_binary();
+
+    // First, create a state file with a real session_id (PreCompact works normally)
+    let real_session_id = format!("test-empty-workaround-{}", std::process::id());
+    Command::new(&binary)
+        .args([
+            "hook",
+            "precompact",
+            &format!("--session-id={}", real_session_id),
+            "--trigger=auto",
+        ])
+        .output()
+        .expect("Failed to execute precompact");
+
+    // Verify state file was created
+    let cache_dir = dirs::cache_dir().unwrap().join("claudia-statusline");
+    let state_file = cache_dir.join(format!("state-{}.json", real_session_id));
+    assert!(
+        state_file.exists(),
+        "State file should exist after precompact"
+    );
+
+    // Run postcompact with empty session_id via stdin JSON (simulates Claude Code bug #9567)
+    // This tests the reset_all_sessions_max_tokens() workaround
+    let hook_json = r#"{"session_id": "", "hook_event_name": "SessionStart"}"#;
+    let mut child = Command::new(&binary)
+        .args(["hook", "postcompact"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn postcompact");
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(hook_json.as_bytes())
+        .expect("Failed to write stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for output");
+
+    assert!(
+        output.status.success(),
+        "PostCompact should succeed with empty session_id from stdin"
+    );
+
+    // Note: The state file for real_session_id won't be cleared because
+    // clear_state("") looks for state-.json, not state-{real_session_id}.json
+    // This is expected behavior - the workaround resets the DATABASE, not state files.
+    // In real usage, PreCompact also receives empty session_id, creating state-.json.
+
+    // Verify output confirms processing
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("PostCompact hook processed"),
+        "Should confirm PostCompact was processed"
+    );
+
+    // Cleanup
+    let _ = fs::remove_file(&state_file);
+}


### PR DESCRIPTION
## Summary

  - Add dedicated PostCompact hook handler that fires via Claude Code's SessionStart[compact] event
  - Properly cleans up compaction state and resets token tracking after compaction completes
  - Fixes persistent "Compacting..." display issue after auto-compact events
  - Fix context % showing historical MAX instead of CURRENT tokens after compaction
  - Add workaround for Claude Code bug #9567 (empty session_id in hooks)

## Changes

  - `src/hook_handler.rs`: Add `handle_postcompact()` function that clears state file and resets max_tokens_observed
  - `src/database.rs`: Add `reset_session_max_tokens()` and `reset_all_sessions_max_tokens()` methods
  - `src/main.rs`: Add `Postcompact` CLI subcommand
  - `src/utils.rs`: Fix MAX→LAST token tracking for accurate context % display
  - `tests/hook_integration_tests.rs`: Add 4 integration tests
  - `docs/USAGE.md`: Update hook configuration examples
  - `README.md`: Update hook setup in collapsible section

## Hook Lifecycle

  1. PreCompact fires      → Creates state file    → Statusline shows "Compacting..."
  2. Compaction runs...
  3. SessionStart[compact] → Clears state + resets → Statusline returns to normal

## Configuration

  ```json
  {
    "hooks": {
      "PreCompact": [{"hooks": [{"type": "command", "command": "statusline hook precompact"}]}],
      "SessionStart": [{"matcher": "compact", "hooks": [{"type": "command", "command": "statusline hook postcompact"}]}]
    }
  }
```

Test plan

  - All 4 new PostCompact integration tests pass
  - Full compaction lifecycle test verifies 3-phase transition
  - Idempotency test confirms safe to call multiple times
  - All 234 existing lib tests pass
  - Manual test with real auto-compaction event

Backwards Compatibility

This is a non-breaking enhancement. Without hooks configured, the statusline continues to work using Phase 2 token-based heuristic detection.