### PR TITLE
Unify duplicated render/stats flow between main.rs and lib.rs (#32)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub mod migrations;
 pub mod models;
 /// Data provider system for parallel variable collection
 pub mod provider;
+/// Shared statusline rendering logic (stats-update flow used by the binary and the embedding API)
+pub mod render;
 /// Retry logic with exponential backoff for transient failures
 pub mod retry;
 /// Hook-based state management for real-time event tracking
@@ -138,133 +140,8 @@ pub fn render_statusline(input: &StatuslineInput, update_stats: bool) -> Result<
     // Get session ID
     let session_id = input.session_id.as_deref();
 
-    // Load or update stats
-    let daily_total = if update_stats && session_id.is_some() {
-        // Update stats with new data
-        if let Some(ref cost) = input.cost {
-            if let Some(total_cost) = cost.total_cost_usd {
-                // Extract model name and workspace directory
-                let model_name = input
-                    .model
-                    .as_ref()
-                    .and_then(|m| m.display_name.as_ref())
-                    .map(|s| s.as_str());
-                let workspace_dir = input
-                    .workspace
-                    .as_ref()
-                    .and_then(|w| w.current_dir.as_ref())
-                    .map(|s| s.as_str());
-
-                // Extract token breakdown from transcript if available
-                let token_breakdown = input
-                    .transcript
-                    .as_ref()
-                    .and_then(|path| utils::get_token_breakdown_from_transcript(path));
-
-                // Get device ID for audit trail
-                let device_id = common::get_device_id();
-
-                use crate::database::SessionUpdate;
-                let (daily_total, _monthly_total) = stats::update_stats_data(|data| {
-                    data.update_session(
-                        session_id.unwrap(),
-                        SessionUpdate {
-                            cost: total_cost,
-                            lines_added: cost.total_lines_added.unwrap_or(0),
-                            lines_removed: cost.total_lines_removed.unwrap_or(0),
-                            model_name: model_name.map(|s| s.to_string()),
-                            workspace_dir: workspace_dir.map(|s| s.to_string()),
-                            device_id: Some(device_id),
-                            token_breakdown,
-                            max_tokens_observed: None, // updated separately
-                            // active_time_seconds / last_activity are owned and computed by
-                            // SqliteDatabase::update_session (src/database/session.rs); not available at
-                            // this SessionUpdate construction site. v3.0.0 cleanup per CONTEXT.md D-13.
-                            active_time_seconds: None,
-                            last_activity: None,
-                        },
-                    )
-                });
-                daily_total
-            } else {
-                // Have session but no cost data - still load existing daily totals
-                let data = stats::get_or_load_stats_data();
-                stats::get_daily_total(&data)
-            }
-        } else {
-            // No cost data - just get current daily total
-            let data = stats::get_or_load_stats_data();
-            stats::get_daily_total(&data)
-        }
-    } else {
-        // Just get current daily total without updating
-        let stats_data = stats::get_or_load_stats_data();
-        stats::get_daily_total(&stats_data)
-    };
-
-    // Track max_tokens_observed for compaction detection
-    // This runs regardless of adaptive_learning setting
-    if update_stats {
-        if let (Some(transcript), Some(session)) = (transcript_path, session_id) {
-            if let Some(current_tokens) = utils::get_token_count_from_transcript(transcript) {
-                // Update session's max_tokens_observed
-                // This updates both in-memory stats and SQLite database
-                stats::update_stats_data(|data| {
-                    data.update_max_tokens(session, current_tokens);
-                    // Return unchanged totals (we're just updating token tracking)
-                    use crate::common::{current_date, current_month};
-                    let today = current_date();
-                    let month = current_month();
-                    let daily_total = data.daily.get(&today).map(|d| d.total_cost).unwrap_or(0.0);
-                    let monthly_total = data
-                        .monthly
-                        .get(&month)
-                        .map(|m| m.total_cost)
-                        .unwrap_or(0.0);
-                    (daily_total, monthly_total)
-                });
-
-                // Adaptive context learning: observe token usage if enabled
-                if let Some(model) = model_name {
-                    let config = config::get_config();
-                    if config.context.adaptive_learning {
-                        // Get previous token count from session stats
-                        let stats_data = stats::get_or_load_stats_data();
-                        let previous_tokens = stats_data
-                            .sessions
-                            .get(session)
-                            .and_then(|s| s.max_tokens_observed)
-                            .map(|t| t as usize);
-
-                        // Create context learner and observe usage
-                        use crate::common::get_data_dir;
-                        use crate::context_learning::ContextLearner;
-                        use crate::database::SqliteDatabase;
-
-                        let db_path = get_data_dir().join("stats.db");
-                        if let Ok(db) = SqliteDatabase::new(&db_path) {
-                            let learner = ContextLearner::new(db);
-                            // Extract workspace_dir and device_id for audit trail
-                            let workspace_dir = input
-                                .workspace
-                                .as_ref()
-                                .and_then(|w| w.current_dir.as_deref());
-                            let device_id = crate::common::get_device_id();
-                            // Ignore errors from adaptive learning - it's experimental and shouldn't block statusline
-                            let _ = learner.observe_usage(
-                                model,
-                                current_tokens as usize,
-                                previous_tokens,
-                                Some(transcript),
-                                workspace_dir,
-                                Some(&device_id),
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
+    // Load or update stats (single shared implementation; see src/render.rs).
+    let daily_total = render::update_stats_and_daily_total(input, update_stats);
 
     // Format the output to string
     let output = display::format_output_to_string(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod migrations;
 mod models;
 #[allow(dead_code)]
 mod provider;
+mod render;
 mod retry;
 mod state;
 mod stats;
@@ -56,7 +57,6 @@ mod version;
 use display::{format_output, Colors};
 use error::Result;
 use models::StatuslineInput;
-use stats::{get_or_load_stats_data, update_stats_data};
 use version::version_string;
 
 /// Claudia Statusline - A high-performance statusline for Claude Code
@@ -419,145 +419,9 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Update stats tracking if we have session and cost data
-    let (daily_total, _monthly_total) =
-        if let (Some(session_id), Some(ref cost)) = (&input.session_id, &input.cost) {
-            if let Some(total_cost) = cost.total_cost_usd {
-                // Extract model name and workspace directory
-                let model_name = input
-                    .model
-                    .as_ref()
-                    .and_then(|m| m.display_name.as_ref())
-                    .map(|s| s.as_str());
-                let workspace_dir = input
-                    .workspace
-                    .as_ref()
-                    .and_then(|w| w.current_dir.as_ref())
-                    .map(|s| s.as_str());
-
-                // Extract token breakdown from transcript if available
-                let token_breakdown = input
-                    .transcript
-                    .as_ref()
-                    .and_then(|path| utils::get_token_breakdown_from_transcript(path));
-
-                // Get device ID for audit trail
-                let device_id = common::get_device_id();
-
-                // Update stats with new cost data
-                use database::SessionUpdate;
-                let result = update_stats_data(|data| {
-                    data.update_session(
-                        session_id,
-                        SessionUpdate {
-                            cost: total_cost,
-                            lines_added: cost.total_lines_added.unwrap_or(0),
-                            lines_removed: cost.total_lines_removed.unwrap_or(0),
-                            model_name: model_name.map(|s| s.to_string()),
-                            workspace_dir: workspace_dir.map(|s| s.to_string()),
-                            device_id: Some(device_id.clone()),
-                            token_breakdown,
-                            max_tokens_observed: None, // updated separately
-                            // active_time_seconds / last_activity are owned and computed by
-                            // SqliteDatabase::update_session (src/database/session.rs); not available at
-                            // this SessionUpdate construction site. v3.0.0 cleanup per CONTEXT.md D-13.
-                            active_time_seconds: None,
-                            last_activity: None,
-                        },
-                    )
-                });
-
-                // Track max_tokens_observed for compaction detection
-                // This runs regardless of adaptive_learning setting
-                if let Some(ref transcript_path) = input.transcript {
-                    if let Some(current_tokens) =
-                        utils::get_token_count_from_transcript(transcript_path)
-                    {
-                        // Update session's max_tokens_observed
-                        // This updates both in-memory stats and SQLite database
-                        update_stats_data(|data| {
-                            data.update_max_tokens(session_id, current_tokens);
-                            // Return unchanged totals
-                            use common::{current_date, current_month};
-                            let today = current_date();
-                            let month = current_month();
-                            let daily_total =
-                                data.daily.get(&today).map(|d| d.total_cost).unwrap_or(0.0);
-                            let monthly_total = data
-                                .monthly
-                                .get(&month)
-                                .map(|m| m.total_cost)
-                                .unwrap_or(0.0);
-                            (daily_total, monthly_total)
-                        });
-
-                        // Adaptive context learning: observe token usage if enabled
-                        if let Some(model_name) =
-                            input.model.as_ref().and_then(|m| m.display_name.as_ref())
-                        {
-                            let config = config::get_config();
-                            if config.context.adaptive_learning {
-                                // Get previous token count from session stats
-                                let stats_data = get_or_load_stats_data();
-                                let previous_tokens = stats_data
-                                    .sessions
-                                    .get(session_id)
-                                    .and_then(|s| s.max_tokens_observed)
-                                    .map(|t| t as usize);
-
-                                // Create context learner and observe usage
-                                use common::get_data_dir;
-                                use context_learning::ContextLearner;
-                                use database::SqliteDatabase;
-
-                                let db_path = get_data_dir().join("stats.db");
-                                if let Ok(db) = SqliteDatabase::new(&db_path) {
-                                    let learner = ContextLearner::new(db);
-                                    // Ignore errors from adaptive learning - it's experimental
-                                    // Re-use device_id retrieved earlier for consistency
-                                    let _ = learner.observe_usage(
-                                        model_name,
-                                        current_tokens as usize,
-                                        previous_tokens,
-                                        Some(transcript_path),
-                                        workspace_dir,
-                                        Some(&device_id),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                result
-            } else {
-                // Have session but no cost data - still load existing daily totals
-                let data = get_or_load_stats_data();
-                let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-                let month = chrono::Local::now().format("%Y-%m").to_string();
-
-                let daily_total = data.daily.get(&today).map(|d| d.total_cost).unwrap_or(0.0);
-                let monthly_total = data
-                    .monthly
-                    .get(&month)
-                    .map(|m| m.total_cost)
-                    .unwrap_or(0.0);
-                (daily_total, monthly_total)
-            }
-        } else {
-            // No session_id - still load stats data to show accumulated totals
-            let data = get_or_load_stats_data();
-            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-            let month = chrono::Local::now().format("%Y-%m").to_string();
-
-            let daily_total = data.daily.get(&today).map(|d| d.total_cost).unwrap_or(0.0);
-            let monthly_total = data
-                .monthly
-                .get(&month)
-                .map(|m| m.total_cost)
-                .unwrap_or(0.0);
-            (daily_total, monthly_total)
-        };
+    // Update stats and resolve today's daily total via the single shared
+    // implementation (see src/render.rs). The binary always updates stats.
+    let daily_total = render::update_stats_and_daily_total(&input, true);
 
     // Format and print output
     format_output(

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,149 @@
+//! Shared statusline rendering logic.
+//!
+//! The binary entry point (`main`) and the [`crate::render_statusline`] embedding API
+//! historically duplicated the stats-update flow (session cost update → max-token
+//! tracking for compaction detection → adaptive context learning). The two copies had
+//! drifted, so any fix applied to one path could silently miss the other (see issue #32).
+//!
+//! This module holds the single implementation of that flow. Both crate roots
+//! (`src/main.rs` and `src/lib.rs`) compile the same module files, so the binary and the
+//! library share this function directly.
+
+use crate::models::StatuslineInput;
+
+/// Apply persistent stats updates for `input` and return today's daily cost total.
+///
+/// When `update_stats` is `true` and the input carries a session id, this:
+/// 1. records the session's cost / lines / token breakdown (when `cost.total_cost_usd`
+///    is present),
+/// 2. tracks `max_tokens_observed` for compaction detection whenever a transcript is
+///    available (independent of cost), and
+/// 3. runs adaptive context learning when it is enabled in config.
+///
+/// When `update_stats` is `false`, or no session/cost is present, it performs no writes
+/// for that step and simply reads back today's accumulated daily total.
+///
+/// The returned value is the daily total observed immediately after the cost update
+/// (the later max-token write does not change the returned figure), matching the prior
+/// behavior of both call sites.
+pub fn update_stats_and_daily_total(input: &StatuslineInput, update_stats: bool) -> f64 {
+    use crate::{common, config, stats, utils};
+
+    let model_name = input.model.as_ref().and_then(|m| m.display_name.as_deref());
+    let transcript_path = input.transcript.as_deref();
+    let session_id = input.session_id.as_deref();
+
+    // 1. Session cost update (or read-back of the existing daily total).
+    let daily_total = if update_stats {
+        if let (Some(session_id), Some(cost)) = (session_id, input.cost.as_ref()) {
+            if let Some(total_cost) = cost.total_cost_usd {
+                let workspace_dir = input
+                    .workspace
+                    .as_ref()
+                    .and_then(|w| w.current_dir.as_deref());
+
+                // Extract token breakdown from transcript if available.
+                let token_breakdown =
+                    transcript_path.and_then(utils::get_token_breakdown_from_transcript);
+
+                // Device ID for the audit trail.
+                let device_id = common::get_device_id();
+
+                use crate::database::SessionUpdate;
+                let (daily_total, _monthly_total) = stats::update_stats_data(|data| {
+                    data.update_session(
+                        session_id,
+                        SessionUpdate {
+                            cost: total_cost,
+                            lines_added: cost.total_lines_added.unwrap_or(0),
+                            lines_removed: cost.total_lines_removed.unwrap_or(0),
+                            model_name: model_name.map(|s| s.to_string()),
+                            workspace_dir: workspace_dir.map(|s| s.to_string()),
+                            device_id: Some(device_id),
+                            token_breakdown,
+                            max_tokens_observed: None, // updated separately below
+                            // active_time_seconds / last_activity are owned and computed by
+                            // SqliteDatabase::update_session (src/database/session.rs); not available
+                            // at this SessionUpdate construction site. v3.0.0 cleanup per CONTEXT.md D-13.
+                            active_time_seconds: None,
+                            last_activity: None,
+                        },
+                    )
+                });
+                daily_total
+            } else {
+                // Session present but no cost figure — read back existing daily total.
+                stats::get_daily_total(&stats::get_or_load_stats_data())
+            }
+        } else {
+            // No session/cost to update — read back existing daily total.
+            stats::get_daily_total(&stats::get_or_load_stats_data())
+        }
+    } else {
+        // Not updating stats — just read back today's accumulated daily total.
+        stats::get_daily_total(&stats::get_or_load_stats_data())
+    };
+
+    // 2. Track max_tokens_observed for compaction detection.
+    //    Runs whenever a transcript + session are present, regardless of cost.
+    if update_stats {
+        if let (Some(transcript), Some(session)) = (transcript_path, session_id) {
+            if let Some(current_tokens) = utils::get_token_count_from_transcript(transcript) {
+                // Updates both in-memory stats and the SQLite database.
+                stats::update_stats_data(|data| {
+                    data.update_max_tokens(session, current_tokens);
+                    // Return unchanged totals (this step only updates token tracking).
+                    use crate::common::{current_date, current_month};
+                    let today = current_date();
+                    let month = current_month();
+                    let daily = data.daily.get(&today).map(|d| d.total_cost).unwrap_or(0.0);
+                    let monthly = data
+                        .monthly
+                        .get(&month)
+                        .map(|m| m.total_cost)
+                        .unwrap_or(0.0);
+                    (daily, monthly)
+                });
+
+                // 3. Adaptive context learning: observe token usage if enabled.
+                if let Some(model) = model_name {
+                    let config = config::get_config();
+                    if config.context.adaptive_learning {
+                        // Previous token count from session stats, for delta-based learning.
+                        let previous_tokens = stats::get_or_load_stats_data()
+                            .sessions
+                            .get(session)
+                            .and_then(|s| s.max_tokens_observed)
+                            .map(|t| t as usize);
+
+                        use crate::common::get_data_dir;
+                        use crate::context_learning::ContextLearner;
+                        use crate::database::SqliteDatabase;
+
+                        let db_path = get_data_dir().join("stats.db");
+                        if let Ok(db) = SqliteDatabase::new(&db_path) {
+                            let learner = ContextLearner::new(db);
+                            let workspace_dir = input
+                                .workspace
+                                .as_ref()
+                                .and_then(|w| w.current_dir.as_deref());
+                            let device_id = common::get_device_id();
+                            // Adaptive learning is experimental; ignore errors so it never blocks
+                            // the statusline.
+                            let _ = learner.observe_usage(
+                                model,
+                                current_tokens as usize,
+                                previous_tokens,
+                                Some(transcript),
+                                workspace_dir,
+                                Some(&device_id),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    daily_total
+}


### PR DESCRIPTION
Closes #32.

## Problem

`main()` reimplemented the ~155-line stats-update flow (session cost update → max-token tracking for compaction detection → adaptive context learning) instead of sharing it with the public `render_statusline()` embedding API. The two copies had already drifted, so a fix applied to one path could silently miss the other. `lib.rs` also had a `session_id.unwrap()` deep inside a nested closure, guarded far away.

## Change

Extract the flow into a single shared module, **`src/render.rs`** (`update_stats_and_daily_total`), called by both `main()`'s default path and `render_statusline()`.

- The binary and library are separate crates that each compile the module files, so the helper lives in a shared file declared in both crate roots (not in a crate root itself).
- Removes the `session_id.unwrap()` (destructured `if let (Some(session_id), Some(cost)) = …` guard instead).
- Aligns `main` to `lib`'s **cost-independent** max-token tracking — strictly more correct for compaction detection, and a no-op in practice since Claude Code always sends cost.
- **Keeps each path's own output call:** `main` uses `format_output` (which routes through the layout/template engine); `render_statusline` uses `format_output_to_string` (which intentionally does not). Fully delegating `main → render_statusline` would have silently broken custom-layout rendering in the binary, so only the genuinely-duplicated stats flow was unified.

Net: ~270 duplicated lines collapsed into one ~149-line module.

## Acceptance criteria

- [x] Single implementation of the stats-update flow (`main.rs:424` and `lib.rs:144` both call `render::update_stats_and_daily_total`)
- [x] No `unwrap()` on `session_id` in the render path
- [x] Existing integration tests + `lib_api_tests` pass unchanged

## Verification

- Full suite: **1059 passed, 0 failed, 19 ignored**
- `cargo clippy --all-targets --all-features -- -D warnings` clean (CI flags)
- `cargo fmt --all -- --check` clean
- Binary smoke test renders correctly: `/tmp • O4.5 • +150 -42 • $3.50 (day: …)`, exit 0

## Notes

- The pre-existing flaky `test_concurrent_stats_updates` (fails only under full-suite parallelism, passes in isolation) is unrelated to this change — tracked by #34.