### PR TITLE
Resettable config cache + re-enable config-dependent tests (#34)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1319,13 +1319,53 @@ inherit_duration_mode = true
 }
 
 // Global configuration instance
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
-static CONFIG: OnceLock<Config> = OnceLock::new();
+/// Cached global configuration.
+///
+/// Stored as a leaked `&'static Config` so callers keep the ergonomic `&'static`
+/// return type. A `RwLock` (rather than `OnceLock`) backs it so tests can reset the
+/// cache via [`reset_config`]: the env vars consulted in [`build_config`] are read once
+/// at first access, and without a reset an env var set by an earlier test (or left over
+/// from one) would be frozen in for the rest of the process, polluting later
+/// config-dependent assertions (issue #34).
+static CONFIG: RwLock<Option<&'static Config>> = RwLock::new(None);
 
-/// Get the global configuration instance
+/// Get the global configuration instance.
+///
+/// Built once on first call (from the config file plus environment overrides) and cached
+/// for the lifetime of the process. Tests may call [`reset_config`] to force a rebuild.
 pub fn get_config() -> &'static Config {
-    CONFIG.get_or_init(|| {
+    // Fast path: already initialized.
+    if let Some(cfg) = *CONFIG.read().expect("config lock poisoned") {
+        return cfg;
+    }
+    // Slow path: build once and cache. Re-check under the write lock in case another
+    // thread initialized while we were waiting for it.
+    let mut guard = CONFIG.write().expect("config lock poisoned");
+    if let Some(cfg) = *guard {
+        return cfg;
+    }
+    let leaked: &'static Config = Box::leak(Box::new(build_config()));
+    *guard = Some(leaked);
+    leaked
+}
+
+/// Reset the cached configuration so the next [`get_config`] rebuilds from the current
+/// environment and config file.
+///
+/// Exists so tests can obtain deterministic, env-dependent config despite the
+/// process-global cache; production code never calls it. Resetting leaks the previously
+/// cached `Config`, which is harmless for the bounded number of resets in a test run.
+#[doc(hidden)]
+#[allow(dead_code)] // Used by lib/integration tests; not called from the binary.
+pub fn reset_config() {
+    *CONFIG.write().expect("config lock poisoned") = None;
+}
+
+/// Build a fully-resolved [`Config`] from the config file plus environment overrides.
+fn build_config() -> Config {
+    {
         let mut config = Config::load().unwrap_or_else(|e| {
             warn!("Failed to load config: {}. Using defaults.", e);
             Config::default()
@@ -1388,7 +1428,7 @@ pub fn get_config() -> &'static Config {
         warn_json_backup_legacy_if_set(&config);
 
         config
-    })
+    }
 }
 
 static JSON_BACKUP_DEPRECATION_WARNED: OnceLock<()> = OnceLock::new();
@@ -1418,6 +1458,52 @@ pub fn get_theme() -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_config_reset_picks_up_env_changes() {
+        // Proves the anti-pollution guarantee from issue #34: the process-global config
+        // cache must not freeze env-derived values across a reset.
+        let original_theme = env::var("STATUSLINE_THEME").ok();
+        let original_claude_theme = env::var("CLAUDE_THEME").ok();
+        // CLAUDE_THEME takes precedence over STATUSLINE_THEME in build_config; clear it so
+        // this test controls the resolved theme deterministically.
+        env::remove_var("CLAUDE_THEME");
+
+        env::set_var("STATUSLINE_THEME", "dark");
+        reset_config();
+        assert_eq!(
+            get_config().display.theme,
+            "dark",
+            "config should reflect the environment after a reset"
+        );
+
+        // Without a reset the cache holds the previously built value.
+        env::set_var("STATUSLINE_THEME", "light");
+        assert_eq!(
+            get_config().display.theme,
+            "dark",
+            "cached config should not change until reset"
+        );
+
+        // After a reset it must pick up the new value (no stale cache pollution).
+        reset_config();
+        assert_eq!(
+            get_config().display.theme,
+            "light",
+            "config must reflect the current environment after reset"
+        );
+
+        // Restore prior environment and rebuild so later tests see a clean cache.
+        match original_theme {
+            Some(v) => env::set_var("STATUSLINE_THEME", v),
+            None => env::remove_var("STATUSLINE_THEME"),
+        }
+        if let Some(v) = original_claude_theme {
+            env::set_var("CLAUDE_THEME", v);
+        }
+        reset_config();
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1285,7 +1285,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Skip in CI where NO_COLOR is set
+    // Deliberate skip (#34): depends on NO_COLOR being unset, but NO_COLOR is a
+    // process-global env var read live by Colors::enabled(). CI sets it globally, and
+    // parallel (non-serial) tests in this binary toggle it, so the result is
+    // nondeterministic. A robust re-enable needs non-global color enablement.
+    #[ignore = "global NO_COLOR env race; CI sets NO_COLOR — see issue #34"]
     fn test_theme_affects_colors() {
         // Use RAII guard to ensure clean environment
         let _guard = ClearNoColor::new();

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -123,15 +123,20 @@ fn test_stats_save_and_load() {
 
 #[test]
 #[serial]
-#[ignore = "Flaky test - OnceLock config caching can cause start_time to differ between runs"]
 fn test_session_start_time_tracking() {
     use crate::database::SessionUpdate;
     use tempfile::TempDir;
 
-    // Isolate from real database
+    // Isolate from the real database AND config. The prior flakiness was the global
+    // config cache (issue #34): a leaked STATUSLINE_BURN_RATE_MODE=auto_reset frozen in
+    // by an earlier test made update_session take the session-reset path, which changes
+    // start_time. Clear it and rebuild config from the isolated (empty) config dir so
+    // burn_rate.mode is the default "wall_clock" and start_time is stable.
     let temp_dir = TempDir::new().unwrap();
     env::set_var("XDG_DATA_HOME", temp_dir.path());
     env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+    env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    crate::config::reset_config();
 
     let mut stats = StatsData::default();
 
@@ -178,9 +183,10 @@ fn test_session_start_time_tracking() {
     assert_eq!(session.start_time, original_start);
     assert_eq!(session.cost, 2.0);
 
-    // Cleanup
+    // Cleanup; rebuild config so later tests get a clean cache.
     env::remove_var("XDG_DATA_HOME");
     env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 #[test]
@@ -275,9 +281,10 @@ fn test_concurrent_update_safety() {
 
 #[test]
 #[serial]
-#[ignore = "Flaky test - stack overflow due to deep test isolation nesting"]
 fn test_get_session_duration() {
-    // Skip this test in CI due to timing issues
+    // Runs locally; skipped under CI where the shared, time-sensitive setup is least
+    // reliable. (The previous "stack overflow due to deep test isolation nesting" reason
+    // was inaccurate — get_session_duration has no recursion; see issue #34.)
     if env::var("CI").is_ok() {
         println!("Skipping test_get_session_duration in CI environment");
         return;
@@ -289,6 +296,9 @@ fn test_get_session_duration() {
     let temp_path = temp_dir.path().to_str().unwrap();
     env::set_var("XDG_DATA_HOME", temp_path);
     env::set_var("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap());
+    // Rebuild config from the isolated dir so burn_rate.mode is deterministic (#34).
+    env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    crate::config::reset_config();
 
     // Create the directory structure
     let stats_dir = Path::new(&temp_path).join("claudia-statusline");
@@ -339,6 +349,8 @@ fn test_get_session_duration() {
     assert!(get_session_duration("non-existent-session").is_none());
 
     env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 #[test]

--- a/tests/display_config_integration.rs
+++ b/tests/display_config_integration.rs
@@ -283,8 +283,13 @@ fn test_no_double_separators_regression() {
 }
 
 #[test]
-#[serial_test::serial] // Run serially to avoid NO_COLOR env var conflicts
-#[ignore] // Flaky: NO_COLOR env var can be cached by earlier tests
+#[serial_test::serial]
+// Run serially to avoid NO_COLOR env var conflicts
+// Deliberate skip (#34): NO_COLOR is read live by Colors::enabled() (not cached), but it
+// is a process-global env var. #[serial] only excludes other #[serial] tests, so a
+// non-serial test in this binary can clear/set NO_COLOR concurrently and flip the result.
+// A robust re-enable needs non-global color enablement.
+#[ignore = "global NO_COLOR env race under parallel tests — see issue #34"]
 fn test_with_no_color_env() {
     let _guard = test_support::init();
     // Save original state


### PR DESCRIPTION
Addresses #34 (and the test-isolation class in #23).

## Investigation first — the issue's root causes were largely inaccurate

I cataloged all 10 `#[ignore]`d tests. The stated causes didn't hold up:

- `test_session_start_time_tracking` ("OnceLock config caching") — never calls `get_config()` directly; the *real* trigger is a leaked `STATUSLINE_BURN_RATE_MODE=auto_reset` frozen in the global config cache, which makes `update_session` take the session-reset path and change `start_time`.
- `test_get_session_duration` ("stack overflow from recursion") — `get_session_duration` has **no recursion**; the reason is false. It also already has a CI-skip guard.
- `test_with_no_color_env` / `test_theme_affects_colors` ("NO_COLOR cached") — `Colors::enabled()` reads `NO_COLOR` **live** every call; it's a process-global env race, not caching.

The unifying real cause is process-global env vars (config cache, `NO_COLOR`, `XDG_*`) frozen or raced across the shared test process.

## Changes

**Infrastructure — the named "no global-config pollution" criterion:**
- Replaced `OnceLock<Config>` with a resettable `RwLock<Option<&'static Config>>` (callers keep the `&'static Config` return type via a leaked box).
- Added `config::reset_config()` (`#[doc(hidden)]`) so tests get deterministic, env-dependent config. Production never calls it.
- Added a proving unit test: config reflects env changes only after a reset.

**Safe re-enables:**
- `test_session_start_time_tracking` — clear `STATUSLINE_BURN_RATE_MODE` + `reset_config()` so `burn_rate.mode` is the default `wall_clock`. **Stable across 8× parallel stress runs.**
- `test_get_session_duration` — removed the false "stack overflow" reason; kept its CI guard (zero CI risk) + added config reset for local determinism.

**Corrected documented skips** (genuine global-`NO_COLOR` env races, not caching):
- `test_theme_affects_colors`, `test_with_no_color_env` — fixed inaccurate `#[ignore]` reasons; a robust re-enable needs non-global color enablement.

**Left ignored (out of scope):** the genuine SQLite-locking, thread-timing, filesystem-timing, parallel-timestamp, and corrupted-DB-fixture tests.

Net: ignore attributes 10 → 8.

## Acceptance criteria

- [x] No global-config cache pollution between tests (resettable cache + proving test)
- [x] Targeted ignores re-enabled (the 2 config/recursion-named ones) or converted to accurate documented skips (the NO_COLOR ones)

## Verification

- Re-enabled tests stable across **8/8** full-lib parallel stress runs
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean
- Diff is **confined to `config.rs` + test files** — zero DB/migration/persistence changes

## Heads-up (separate, pre-existing — not this PR)

While verifying I confirmed a pre-existing **concurrent first-run migration race** (`UNIQUE constraint failed: schema_migrations.version`) that can make the *full local suite* flake under heavy parallelism (~1 in 6 full `cargo test` invocations; every clean run is 1065/0). All 40 direct concurrent binary spawns exit 0 — the binary is resilient. This is **issue #33** and is untouched here. #32's identical CI passed cleanly.