### PR TITLE
Stats atomicity invariant + concurrency-safe first-run migration (#33)

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -70,7 +70,8 @@ impl SqliteDatabase {
 
         // Open connection directly - avoids thread-spawning issues on FreeBSD
         // (r2d2's scheduled-thread-pool fails with EAGAIN on FreeBSD)
-        let conn = Connection::open(db_path)?;
+        // `mut` is required for the IMMEDIATE transaction used in the new-db init path.
+        let mut conn = Connection::open(db_path)?;
 
         // Apply pragmas for WAL mode and concurrency
         conn.pragma_update(None, "journal_mode", "WAL")?;
@@ -93,15 +94,40 @@ impl SqliteDatabase {
         let is_new_db = !has_sessions_table;
 
         if is_new_db {
-            // NEW DATABASE: Create complete schema with all migration columns
+            // NEW DATABASE: Create complete schema with all migration columns.
+            //
+            // Concurrency safety: `is_new_db` is read outside a transaction, so multiple
+            // fresh processes can all observe "no sessions table" and race here. The
+            // SCHEMA batch is idempotent (all `CREATE TABLE IF NOT EXISTS`), but the
+            // version-record INSERT is not. We therefore record the version inside an
+            // IMMEDIATE transaction (writers serialize at BEGIN) using `INSERT OR IGNORE`
+            // so a lost race never raises `UNIQUE constraint failed:
+            // schema_migrations.version`, and wrap the whole thing in `retry_if_retryable`
+            // so a serialized loser that still hits SQLITE_BUSY retries cleanly. This
+            // mirrors the adapter pattern in `SqliteDatabase::update_session`.
             conn.execute_batch(SCHEMA)?;
 
-            // Mark as fully migrated (v6 includes daily/monthly token tracking)
-            conn.execute(
-                "INSERT INTO schema_migrations (version, applied_at, checksum, description, execution_time_ms)
-                 VALUES (?1, ?2, '', 'New database with complete schema (v6)', 0)",
-                params![6, chrono::Local::now().to_rfc3339()],
-            )?;
+            crate::retry::retry_if_retryable(&crate::retry::RetryConfig::for_db_ops(), || {
+                let tx = conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                    .map_err(crate::error::StatuslineError::Database)?;
+                // Mark as fully migrated (v6 includes daily/monthly token tracking).
+                tx.execute(
+                    "INSERT OR IGNORE INTO schema_migrations (version, applied_at, checksum, description, execution_time_ms)
+                     VALUES (?1, ?2, '', 'New database with complete schema (v6)', 0)",
+                    params![6, chrono::Local::now().to_rfc3339()],
+                )
+                .map_err(crate::error::StatuslineError::Database)?;
+                tx.commit().map_err(crate::error::StatuslineError::Database)?;
+                Ok(())
+            })
+            .map_err(|e| match e {
+                crate::error::StatuslineError::Database(db_err) => db_err,
+                _ => rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                    Some(e.to_string()),
+                ),
+            })?;
         } else {
             // OLD DATABASE: Only ensure base tables exist, let migrations add columns/indexes
             // This prevents "no such column" errors when creating indexes

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -73,9 +73,26 @@ impl SqliteDatabase {
         // `mut` is required for the IMMEDIATE transaction used in the new-db init path.
         let mut conn = Connection::open(db_path)?;
 
-        // Apply pragmas for WAL mode and concurrency
-        conn.pragma_update(None, "journal_mode", "WAL")?;
+        // Apply pragmas for WAL mode and concurrency.
+        //
+        // `busy_timeout` is set FIRST so every subsequent lock acquisition waits. Switching
+        // to WAL still needs special handling: `PRAGMA journal_mode=WAL` takes an exclusive
+        // lock and SQLite can return SQLITE_BUSY *immediately* (without invoking the busy
+        // handler) when other connections hold the database — exactly the contention created
+        // by concurrent first-run opens. Retry the WAL switch with backoff so concurrent
+        // openers converge on WAL instead of surfacing "database is locked".
         conn.pragma_update(None, "busy_timeout", config.database.busy_timeout_ms)?;
+        crate::retry::retry_if_retryable(&crate::retry::RetryConfig::for_db_ops(), || {
+            conn.pragma_update(None, "journal_mode", "WAL")
+                .map_err(crate::error::StatuslineError::Database)
+        })
+        .map_err(|e| match e {
+            crate::error::StatuslineError::Database(db_err) => db_err,
+            _ => rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(e.to_string()),
+            ),
+        })?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
 
         // Check if this is a new database by looking for existing sessions table
@@ -94,22 +111,25 @@ impl SqliteDatabase {
         let is_new_db = !has_sessions_table;
 
         if is_new_db {
-            // NEW DATABASE: Create complete schema with all migration columns.
+            // NEW DATABASE: create the complete schema AND record the version ATOMICALLY.
             //
             // Concurrency safety: `is_new_db` is read outside a transaction, so multiple
-            // fresh processes can all observe "no sessions table" and race here. The
-            // SCHEMA batch is idempotent (all `CREATE TABLE IF NOT EXISTS`), but the
-            // version-record INSERT is not. We therefore record the version inside an
-            // IMMEDIATE transaction (writers serialize at BEGIN) using `INSERT OR IGNORE`
-            // so a lost race never raises `UNIQUE constraint failed:
-            // schema_migrations.version`, and wrap the whole thing in `retry_if_retryable`
-            // so a serialized loser that still hits SQLITE_BUSY retries cleanly. This
-            // mirrors the adapter pattern in `SqliteDatabase::update_session`.
-            conn.execute_batch(SCHEMA)?;
-
+            // fresh processes can all observe "no sessions table" and race here. Both the
+            // SCHEMA batch (idempotent — all `CREATE TABLE/INDEX IF NOT EXISTS`) and the
+            // version record run inside ONE IMMEDIATE transaction (writers serialize at
+            // BEGIN), wrapped in `retry_if_retryable`. Committing schema + version together
+            // is what closes the race: otherwise a second process could observe "sessions
+            // table exists but schema_migrations is empty", take the migration path, and
+            // re-run an `ALTER TABLE ... ADD COLUMN device_id` that the full schema already
+            // created (the `duplicate column name: device_id` failure). `INSERT OR IGNORE`
+            // keeps a lost version-record race from raising `UNIQUE constraint failed:
+            // schema_migrations.version`. Mirrors the adapter pattern in
+            // `SqliteDatabase::update_session`.
             crate::retry::retry_if_retryable(&crate::retry::RetryConfig::for_db_ops(), || {
                 let tx = conn
                     .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                    .map_err(crate::error::StatuslineError::Database)?;
+                tx.execute_batch(SCHEMA)
                     .map_err(crate::error::StatuslineError::Database)?;
                 // Mark as fully migrated (v6 includes daily/monthly token tracking).
                 tx.execute(

--- a/src/display.rs
+++ b/src/display.rs
@@ -263,7 +263,13 @@ fn format_statusline_string(
         if !db_path.exists() {
             return None;
         }
-        crate::database::SqliteDatabase::new(&db_path).ok()
+        match crate::database::SqliteDatabase::new(&db_path) {
+            Ok(db) => Some(db),
+            Err(e) => {
+                log::debug!("Display: failed to open SQLite db at {:?}: {}", db_path, e);
+                None
+            }
+        }
     });
 
     // 0. TEST indicator if in test mode
@@ -627,7 +633,13 @@ fn format_statusline_with_layout(
         if let Some(db) = crate::stats::StatsData::get_sqlite_path()
             .ok()
             .filter(|p| p.exists())
-            .and_then(|p| crate::database::SqliteDatabase::new(&p).ok())
+            .and_then(|p| match crate::database::SqliteDatabase::new(&p) {
+                Ok(db) => Some(db),
+                Err(e) => {
+                    log::debug!("Display: failed to open SQLite db at {:?}: {}", p, e);
+                    None
+                }
+            })
         {
             if let Some(token_rates) = crate::stats::calculate_token_rates_with_db_and_transcript(
                 sid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -807,7 +807,9 @@ fn finalize_migration(delete_json: bool) -> Result<()> {
     // Check if SQLite database exists
     if !sqlite_path.exists() {
         println!("⚠️  SQLite database not found. Creating and migrating...");
-        // Load from JSON and trigger migration
+        // Load from JSON and trigger migration. The value is intentionally discarded;
+        // the side effect (JSON→SQLite migration) is what we want.
+        warn!("SQLite database absent; loading stats to trigger JSON→SQLite migration");
         let _ = stats::StatsData::load();
     }
 

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,6 +1,7 @@
+use crate::retry::{retry_if_retryable, RetryConfig};
 use crate::stats::StatsData;
 use chrono::Local;
-use rusqlite::{params, Connection, Result, Transaction};
+use rusqlite::{params, Connection, Result, Transaction, TransactionBehavior};
 use std::path::Path;
 
 /// Migration trait for database schema changes
@@ -105,8 +106,34 @@ impl MigrationRunner {
         Ok(version.unwrap_or(0))
     }
 
-    /// Run all pending migrations
+    /// Run all pending migrations.
+    ///
+    /// Concurrency-safe under concurrent first-run (multiple fresh processes racing on
+    /// the same DB file). Each migration step runs in an IMMEDIATE transaction so writers
+    /// serialize at BEGIN; the applied version is re-checked INSIDE that transaction to
+    /// close the read-then-write gap; the version is recorded with `INSERT OR IGNORE`
+    /// so a lost race never raises `UNIQUE constraint failed: schema_migrations.version`;
+    /// and the whole thing is wrapped in `retry_if_retryable` so a serialized loser that
+    /// still hits SQLITE_BUSY retries cleanly.
     pub fn migrate(&mut self) -> Result<()> {
+        // Mirror the adapter pattern in SqliteDatabase::update_session: run the loop under
+        // retry_if_retryable (which works over crate::error::Result/StatuslineError), then
+        // map the final StatuslineError back to a rusqlite::Error for our Result signature.
+        retry_if_retryable(&RetryConfig::for_db_ops(), || {
+            self.migrate_once()
+                .map_err(crate::error::StatuslineError::Database)
+        })
+        .map_err(|e| match e {
+            crate::error::StatuslineError::Database(db_err) => db_err,
+            _ => rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+                Some(e.to_string()),
+            ),
+        })
+    }
+
+    /// Single attempt at running pending migrations. Safe to retry.
+    fn migrate_once(&mut self) -> Result<()> {
         let current = self.current_version()?;
 
         // Collect versions to run
@@ -126,16 +153,34 @@ impl MigrationRunner {
                 .find(|m| m.version() == version)
                 .expect("Migration should exist");
 
-            // Run the migration directly instead of calling run_migration
             let start = std::time::Instant::now();
-            let tx = self.conn.transaction()?;
+
+            // IMMEDIATE transaction: concurrent writers serialize at BEGIN, turning a
+            // potential constraint race into a BUSY that retry_if_retryable absorbs.
+            let tx = self
+                .conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+            // Re-check INSIDE the transaction: another process may have applied this
+            // version between our current_version() read and acquiring the write lock.
+            let already_applied: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM schema_migrations WHERE version = ?1",
+                params![migration.version()],
+                |row| row.get(0),
+            )?;
+            if already_applied > 0 {
+                // Already recorded by a concurrent process; don't re-run migration.up.
+                tx.commit()?;
+                continue;
+            }
 
             // Apply migration
             migration.up(&tx)?;
 
-            // Record migration
+            // Record migration. INSERT OR IGNORE so a lost race can never raise
+            // `UNIQUE constraint failed: schema_migrations.version`.
             tx.execute(
-                "INSERT INTO schema_migrations (version, applied_at, checksum, description, execution_time_ms)
+                "INSERT OR IGNORE INTO schema_migrations (version, applied_at, checksum, description, execution_time_ms)
                  VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![
                     migration.version(),

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -137,7 +137,10 @@ impl StatsData {
 
     pub fn save(&self) -> Result<()> {
         // v3.0.0+: writes are SQLite-only. The JSON backup write path was removed.
-        perform_sqlite_dual_write(self);
+        // INVARIANT: this performs no durable write — the durable write for a session
+        // is the transactional `SqliteDatabase::update_session` call. Here we only
+        // ensure the database and its migrations exist (see `ensure_sqlite_initialized`).
+        ensure_sqlite_initialized();
         Ok(())
     }
 }
@@ -155,9 +158,15 @@ pub fn get_or_load_stats_data() -> StatsData {
     StatsData::load()
 }
 
-// Helper function to write to SQLite (primary storage)
-fn perform_sqlite_dual_write(_stats_data: &StatsData) {
-    // Write to SQLite (primary storage as of Phase 2)
+/// Ensures the SQLite database exists and its migrations have run.
+///
+/// INVARIANT: this performs NO durable write of stats data. Its sole effect is to
+/// open (and thereby create + migrate) the SQLite database at the configured path.
+/// The single durable write for a session is the transactional
+/// `SqliteDatabase::update_session` call made inside the `updater` closure of
+/// `update_stats_data` (explicit transaction + `retry_if_retryable`). Do NOT add
+/// file locking here — concurrency safety lives in the SQLite transaction.
+fn ensure_sqlite_initialized() {
     let db_path = match StatsData::get_sqlite_path() {
         Ok(p) => p,
         Err(_) => {
@@ -166,6 +175,8 @@ fn perform_sqlite_dual_write(_stats_data: &StatsData) {
         }
     };
 
+    // Constructing the handle runs `run_migrations_on_db`, guaranteeing the schema
+    // exists. The handle is intentionally dropped: no row is written here.
     let _db = match SqliteDatabase::new(&db_path) {
         Ok(d) => d,
         Err(e) => {
@@ -176,17 +187,23 @@ fn perform_sqlite_dual_write(_stats_data: &StatsData) {
             return;
         }
     };
-
-    // NOTE: Migration is now handled in load_stats_data() when JSON is loaded
-    // Current session is written directly in update_session() with all migration v5 fields
-    // No need to call write_current_session_to_sqlite() as that would overwrite model_name/workspace_dir/tokens with NULL
 }
 
 /// Updates the statistics data, persisting the result to SQLite.
 ///
-/// This function loads the current data, applies the update function, and writes the
-/// result to SQLite. As of v3.0.0 the JSON backup write path (and its `fs2` file lock)
-/// was removed; concurrency safety now rests on the SQLite transaction in the write path.
+/// This function loads the current data, applies the update function, and ensures the
+/// SQLite database is initialized. As of v3.0.0 the JSON backup write path (and its
+/// `fs2` file lock) was removed; concurrency safety now rests on the SQLite transaction
+/// in the write path.
+///
+/// INVARIANT: the single durable write for a session is the transactional
+/// `SqliteDatabase::update_session` call made inside the `updater` closure (explicit
+/// transaction + `retry_if_retryable`, which retries on SQLITE_BUSY/locked/timeout).
+/// The daily/monthly aggregate UPSERTs run in that SAME transaction, so aggregate
+/// atomicity already holds. The surrounding load-modify cycle is NOT a second durable
+/// write; `ensure_sqlite_initialized()` only guarantees the database and its migrations
+/// exist. Do NOT add file locking here — concurrency safety lives in the SQLite
+/// transaction.
 ///
 /// # Arguments
 ///
@@ -238,11 +255,12 @@ where
         StatsData::load()
     });
 
-    // Apply the update
+    // Apply the update. INVARIANT: the durable write happens HERE, inside the closure,
+    // via the transactional `SqliteDatabase::update_session` path — not below.
     let result = updater(&mut stats_data);
 
-    // Save to SQLite (primary storage)
-    perform_sqlite_dual_write(&stats_data);
+    // Not a second durable write: only ensure the DB + migrations exist.
+    ensure_sqlite_initialized();
 
     result
 }


### PR DESCRIPTION
Closes #33. Run via GSD `/gsd:quick` (planner + executor), then independently stress-verified and hardened.

## What changed (the 3 acceptance criteria + the related migration race)

**D1 — aggregate update atomicity → documented invariant.** Verified against the real code: the durable write for a session is `SqliteDatabase::update_session` (`src/database/session.rs`), which runs the session + daily + monthly UPSERTs in **one** explicit transaction wrapped in `retry_if_retryable`. So aggregate atomicity already holds. Rather than add redundant locking (and no `fs2`), the invariant is now documented at the call sites in `src/stats/persistence.rs` ("the load-modify cycle is NOT a second durable write").

**D2 — renamed the misleading no-op.** `perform_sqlite_dual_write(_stats_data)` (a leftover that ignored its arg and wrote nothing post-v3.0.0) → `ensure_sqlite_initialized()` with the dead param dropped; both call sites updated.

**D3 — log before swallowing.** Added `warn!`/`debug!` before the error-swallowing fallbacks in `src/main.rs` (migration-triggering load) and `src/display.rs` (two `SqliteDatabase::new(...)` fallbacks). Intentionally-silent adaptive-learning errors left alone.

**D4 — concurrent first-run migration race (the acute, reproducible bug).** When multiple processes initialize a fresh DB at the same `XDG_DATA_HOME`, three distinct races surfaced. All fixed:
1. `UNIQUE constraint failed: schema_migrations.version` — IMMEDIATE transaction + in-transaction version recheck + `INSERT OR IGNORE` in both `MigrationRunner::migrate` and the new-db init path.
2. `duplicate column name: device_id` — the new-db path created the schema **outside** the version-recording transaction, leaving a window where another process saw "table exists, no version" and took the migration path (re-running an `ALTER ADD COLUMN`). Fixed by committing `execute_batch(SCHEMA)` + the version record **atomically** in one retried IMMEDIATE transaction.
3. `database is locked` — `busy_timeout` was set *after* `journal_mode=WAL`; the WAL switch takes an exclusive lock SQLite can fail with `SQLITE_BUSY` immediately. Fixed by setting `busy_timeout` first and wrapping the WAL switch in `retry_if_retryable`.

## Verification

- **Concurrency reproduction:** 20×64 = **1,280 concurrent invocations** against shared fresh DBs → **0** ERROR / duplicate-column / UNIQUE / locked lines. (Originally reproduced ~1-in-3 per run.)
- **Full `cargo test`:** green across **7 consecutive runs** — the prior ~1/6 `integration_tests` flake (caused by exactly this race) is gone.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all -- --check` clean.
- Diff confined to `src/stats/persistence.rs`, `src/migrations/mod.rs`, `src/database/mod.rs`, `src/main.rs`, `src/display.rs`.

## Note

The GSD executor's first pass cut the failure rate sharply but its lighter self-test reported "clean" while my heavier stress (20×64) still caught the duplicate-column and locked races — both hardened in the final `database/mod.rs` commit. This also resolves the pre-existing flake I'd flagged on #34 and #44.