### PR TITLE
Repo hygiene: ignore tooling output, commit architecture docs, drop stale Makefile var (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ AGENTS.md
 /.planning
 /.planning/
 
+# Understand-Anything knowledge-graph tooling output (generated; regenerate with /understand)
+.understand-anything/
+
 # Temporary files
 *.tmp
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 
 # Configuration
 BINARY_NAME = statusline
-SOURCES = src/main.rs src/models.rs src/git.rs src/stats.rs src/display.rs src/utils.rs src/version.rs
 TARGET_DIR = target
 INSTALL_DIR = $(HOME)/.local/bin
 CARGO_TARGET = release

--- a/docs/architecture/key-flows.md
+++ b/docs/architecture/key-flows.md
@@ -1,0 +1,221 @@
+# Key Flows — Claudia Statusline
+
+> **Source:** Derived from `.understand-anything/knowledge-graph.json` and
+> `docs/architecture/project-map.md`, with call sequences verified against the source at
+> commit `ac29509` (crate version 3.0.0).
+>
+> Function and type names below are real symbols. Paths are repository-relative. This document
+> is descriptive only; it does not propose changes.
+
+---
+
+## 1. App startup flow
+
+Entry: `fn main() -> Result<()>` in `src/main.rs`.
+
+1. **Parse CLI** — `Cli::parse()` (clap derive). Flags include `--log-level`, `--no-color`,
+   `--theme`, `--config`, `--test-mode`, `--version-full`, `--list-vars`.
+2. **Apply environment precedence (CLI > env > config)** — `main` writes resolved values into
+   process env vars so downstream loaders pick them up:
+   - `--log-level` → `RUST_LOG`, then `env_logger::Builder::from_env(...).default_filter_or("warn").init()`.
+   - `--no-color` → `NO_COLOR=1`.
+   - `--theme` → `CLAUDE_THEME` and `STATUSLINE_THEME`.
+   - `--config` → `STATUSLINE_CONFIG_PATH`.
+   - `--test-mode` → `STATUSLINE_TEST_MODE=1` and a redirected `XDG_DATA_HOME`
+     (`~/.local/share-test`) so the run uses an isolated database.
+3. **Early-return modes** (no stdin read):
+   - `--version-full` → prints `version_string()` and returns.
+   - `--list-vars` → `handle_list_vars(&cli)` (runs all providers, prints variables by source).
+4. **Subcommand dispatch** — `match cli.command`:
+   - `Commands::GenerateConfig` → writes `config::Config::example_toml()` to
+     `Config::default_config_path()` (dir `0o700`, file `0o600` on Unix).
+   - `Commands::Migrate { .. }` → `dump_database_schema()` / `run_schema_migrations()` /
+     `finalize_migration(delete_json)` / `show_migration_roadmap()`.
+   - `Commands::DbMaintain { .. }` → `perform_database_maintenance(...)`.
+   - `Commands::Health { json }` → `show_health_report(json)`.
+   - `Commands::Sync { .. }` → `handle_sync_command(...)` (only compiled with the
+     `turso-sync` feature).
+   - `Commands::ContextLearning { .. }` → `handle_context_learning_command(...)`.
+   - `Commands::Hook { action }` → `handle_hook_command(action)` (see flow 2b).
+5. **Default path (no subcommand)** — falls through to the request/render flow below.
+
+---
+
+## 2. Request / render flow
+
+This is the primary path: stdin JSON → rendered status line on stdout.
+
+### 2a. Default binary path (`src/main.rs`, tail of `main`)
+
+1. **Read stdin** — `io::stdin().read_to_string(&mut buffer)`.
+2. **Parse** — `serde_json::from_str::<StatuslineInput>(&buffer)`; on parse error it logs a
+   warning and uses `StatuslineInput::default()` (never fails the line).
+   `StatuslineInput` and related models live in `src/models.rs` (e.g. `ModelType`,
+   `TokenBreakdown`, with `from_name` / `extract_version` / `abbreviation`).
+3. **Resolve current directory** — from `input.workspace.current_dir`, else `env::current_dir()`,
+   else `"~"`. **Early exit:** if empty or `"~"`, print just the directory segment and return.
+4. **Update stats (if `session_id` + `cost.total_cost_usd` present)** — builds a
+   `database::SessionUpdate` (cost, lines added/removed, model name, workspace dir, device id
+   from `common::get_device_id()`, token breakdown from
+   `utils::get_token_breakdown_from_transcript(path)`) and calls
+   `update_stats_data(|data| data.update_session(session_id, SessionUpdate { .. }))`
+   (see flow 3).
+5. **Track context tokens** — `utils::get_token_count_from_transcript(...)` →
+   `stats::update_stats_data(|data| data.update_max_tokens(session, current_tokens))`; this
+   feeds compaction detection and (if enabled) adaptive learning (flow 2c).
+6. **Collect provider variables** — the `ProviderOrchestrator` in `src/provider/mod.rs`
+   (`collect_all`, `register`) gathers data from registered `DataProvider` implementors,
+   including `GsdProvider` (`src/gsd/mod.rs`) and the stats provider.
+7. **Gather git status** — `src/git.rs`: `get_git_status()` →
+   `parse_git_status()` / `parse_git_status_v2()` → `apply_status_codes()` →
+   `format_git_info()` (returns a `GitStatus`).
+8. **Render** — `src/display.rs`: `format_statusline_string()` /
+   `format_statusline_with_layout()` / `format_output_with_config()` assemble the segments,
+   using `format_context_bar()`, `format_token_rates()`, `context_color()`, `cost_color()`,
+   and `Colors`. Theme/layout resolution comes from `src/theme.rs`
+   (`ThemeManager`, `resolve_color`, `load_embedded`, `list_themes`) and `src/layout/`
+   (presets/template/variables, default template `src/templates/default.tmpl`).
+9. **Output** — the assembled string is printed to stdout.
+
+### 2b. Library API path (`src/lib.rs`)
+
+`pub fn render_statusline(input: &StatuslineInput, update_stats: bool) -> Result<String>`
+performs the same logic as 2a steps 3–8 but returns the `String` instead of printing. It is the
+public embedding entry point exercised by `examples/embedding_example.rs`. When
+`update_stats` is true and a `session_id` is present, it calls
+`stats::update_stats_data(|data| data.update_session(..))`; otherwise it loads existing totals
+via `stats::get_or_load_stats_data()` + `stats::get_daily_total(..)`.
+
+### 2c. Hook path (`src/hook_handler.rs`)
+
+Triggered by `Commands::Hook`. Functions: `handle_precompact`, `handle_postcompact`,
+`clear_state_file_directly`. This is the experimental, low-latency compaction-detection path
+that updates state directly rather than going through the full render. Adaptive learning is
+driven from `src/context_learning.rs` (`ContextLearner`: `observe_usage`,
+`is_compaction_event`, `is_manual_compaction`, `record_compaction`,
+`update_ceiling_observation`, `get_learned_window`, `rebuild_from_sessions`).
+
+---
+
+## 3. Data persistence flow
+
+Backed by bundled SQLite via `rusqlite`. JSON is no longer written as of v3.0.0; legacy
+`stats.json` is read once and migrated in.
+
+### Write path
+
+`stats::update_stats_data<F>(updater)` in `src/stats/persistence.rs`:
+
+1. **Load** — `StatsData::load_from_sqlite()`; on failure, falls back to `StatsData::load()`,
+   which reads any legacy `stats.json` and migrates it into SQLite (rather than starting from
+   `default()`, which would drop a v2.x user's history).
+2. **Apply** — runs the caller's `updater(&mut stats_data)` closure (e.g.
+   `StatsData::update_session` / `update_max_tokens` from `src/stats/session.rs` and
+   `src/stats/mod.rs`).
+3. **Persist** — `perform_sqlite_dual_write(&stats_data)` writes back to SQLite (primary
+   storage). Returns the `(daily_total, monthly_total)` tuple from the closure.
+
+### Database layer (`src/database/`)
+
+- `SqliteDatabase::new()` (`src/database/mod.rs`) opens/creates the database and obtains a
+  connection (`get_connection`).
+- On open, migrations run via `migrations::run_migrations_on_db` (`src/migrations/mod.rs`),
+  driven by `MigrationRunner` / `Migration::migrate`. Schema DDL lives in
+  `src/database/schema.rs` (the embedded `SCHEMA` const, `SessionUpdate`).
+- Session writes: `src/database/session.rs` — `update_session`, `update_session_tx`
+  (transactional), `update_max_tokens_observed`, `archive_session`,
+  `get_session_active_time`, `get_session_token_breakdown`, `import_sessions`.
+  `active_time_seconds` / `last_activity` are owned and computed inside
+  `SqliteDatabase::update_session`, not at the `SessionUpdate` construction site.
+- Aggregates and maintenance: `src/database/daily.rs`, `src/database/monthly.rs`,
+  `src/database/analytics.rs`, `src/database/maintenance.rs`, plus `src/stats/aggregation.rs`
+  and `src/stats/cache.rs`.
+
+### Cloud sync (optional, `turso-sync` feature)
+
+`src/sync.rs` — `SyncManager` with `push` / `pull` (and async `push_to_turso_async` /
+`pull_from_turso_async`), reporting via `SyncStatus`. Network/transient failures use the
+retry helper in `src/retry.rs`. The remote Turso schema is in
+`scripts/setup-turso-schema.sql`, applied by `scripts/setup-turso.sh`.
+
+---
+
+## 4. Config and auth flow
+
+### Configuration (`src/config.rs`)
+
+- **Cached load** — `config::get_config() -> &'static Config` initializes a process-global
+  `OnceCell` (`CONFIG.get_or_init`). On first call it runs `Config::load()` (falling back to
+  `Config::default()` with a warning on error), then layers **environment overrides** on top,
+  e.g. `CLAUDE_THEME` (then `STATUSLINE_THEME`) → `config.display.theme`,
+  `STATUSLINE_SHOW_CONTEXT_TOKENS`, `STATUSLINE_BURN_RATE_MODE`,
+  `STATUSLINE_BURN_RATE_THRESHOLD`, `STATUSLINE_BURN_RATE_MIN_DURATION`,
+  `STATUSLINE_TOKEN_RATE_ENABLED`, and more. Net precedence is **CLI flag → env var →
+  config file → default** (the CLI layer is applied in `main` per flow 1).
+- **File discovery / IO** — `find_config_file()` locates the TOML config; `load_from_file()`
+  parses it; `save()` writes it; `example_toml()` renders the documented example;
+  `default_config_path()` resolves the canonical location. `get_effective_threshold()` resolves
+  the active context threshold.
+- **Config types** — `Config` plus the nested `DisplayConfig`, `ContextConfig`, `CostConfig`,
+  `DatabaseConfig`, `RetryConfig` / `RetrySettings`, `BurnRateConfig`, `LayoutConfig`,
+  `ComponentsConfig` (and the per-component `*ComponentConfig` types), `TokenRateConfig`,
+  and `SyncConfig`.
+
+### Auth (sync token resolution)
+
+There is no end-user authentication; the only credential handling is the Turso sync token,
+resolved by `SyncManager::resolve_auth_token(&self, token_config)` in `src/sync.rs`:
+
+- `${VAR_NAME}` → reads env var `VAR_NAME` (errors `StatuslineError::Sync` if unset).
+- `$VAR_NAME` → same, prefix form.
+- otherwise → the literal string is used as the token directly.
+- empty → empty token (sync effectively disabled).
+
+This indirection keeps secrets out of the committed config file.
+
+---
+
+## 5. Test / build / deploy flow
+
+### Test
+
+- **Integration tests** — `tests/` (burn-rate scenarios, `sqlite_integration_tests.rs`,
+  `theme_integration.rs`, `layout_integration_tests.rs`, `display_config_integration.rs`,
+  `hook_integration_tests.rs`, `lib_api_tests.rs`, `context_tokens_display_tests.rs`,
+  `db_maintenance_tests.rs`, `regression_tests.rs`, property tests `proptest_tests.rs`).
+  Shared harness: `tests/test_support.rs` (imported by 21 integration test files).
+- **Inline unit tests** — `src/database/tests.rs`, `src/stats/tests.rs`, `src/gsd/tests.rs`,
+  `src/layout/tests.rs`, and the mock `src/provider/test_provider.rs`.
+- **Run:** `make test` (unit + integration), `make test-sqlite`, `make test-all`,
+  `make test-manual` (isolated test DB), or `cargo test`. `--test-mode` / `STATUSLINE_TEST_MODE`
+  redirects `XDG_DATA_HOME` so tests never touch the production database
+  (`make show-db-path` shows prod vs test paths).
+
+### Build
+
+- **Build script** — `build.rs` runs at compile time and reads `VERSION` (graph edge
+  `VERSION → build.rs`, type `configures`).
+- **Commands** — `make build` / `make release` / `make debug` / `make install`
+  (installs to `~/.local/bin`), or `cargo build --release`. Optional cloud sync:
+  `cargo build --release --features turso-sync`.
+- **Release profile** (`Cargo.toml`): `opt-level = "z"`, `lto = true`, `codegen-units = 1`,
+  `strip = true`, `panic = "abort"`. Quality gates: `make check-code` (`rustfmt` + `clippy`),
+  `make lint`, `make fmt`; dependency policy in `deny.toml`.
+
+### Deploy / release
+
+- **CI** — GitHub Actions in `.github/workflows/`: `build`, `test`, `security`, `release-v2`,
+  `test-binaries`, `test-binaries-fixed`. Per the graph, `build`/`release` jobs run
+  `cargo build --release` (modeled as `deploys → src/main.rs`); `test-binaries*` are
+  `workflow_run`-triggered after `build` completes (`depends_on → build`).
+- **Release tooling** — `scripts/release.sh` (runs/bundles `scripts/install-statusline.sh`),
+  `scripts/bump-version.sh`, and Make targets `bump-major` / `bump-minor` / `bump-patch`,
+  `tag`, `release-build`.
+- **End-user install** — `scripts/quick-install.sh` (the `curl | bash` path in `README.md`)
+  downloads a prebuilt binary; `scripts/install-statusline.sh` installs from a local build;
+  `scripts/uninstall-statusline.sh` removes it.
+
+---
+
+*See `docs/architecture/project-map.md` for the module/layer map, dependency centrality, and
+the list of central/risky files referenced above.*

--- a/docs/architecture/project-map.md
+++ b/docs/architecture/project-map.md
@@ -1,0 +1,202 @@
+# Project Map — Claudia Statusline
+
+> **Source:** Generated from `.understand-anything/knowledge-graph.json`
+> (575 nodes, 767 edges, 10 layers), cross-checked against the repository.
+> **Analyzed commit:** `ac29509` · **Crate version:** 3.0.0 · **Edition:** 2021
+>
+> This document is descriptive only. It records what exists; it does not propose changes.
+
+## High-level overview
+
+Claudia Statusline is a Rust **binary + library** crate (`name = "statusline"`) that renders
+a feature-rich status line for Claude Code. The binary reads a session JSON payload on stdin
+and prints a single formatted line showing workspace/directory, git status, model, context
+usage, session duration, cost, and burn rate.
+
+Key characteristics:
+
+- **Persistent stats** in a bundled SQLite database (via `rusqlite`), with versioned migrations.
+- **Rendering** is configurable: 11 embedded themes, 5 layout presets, and custom templates.
+- **Extension surface** via a `DataProvider` trait and an orchestrator, including GSD
+  (`.planning/`) integration.
+- **Optional cloud sync** to Turso, gated behind the `turso-sync` Cargo feature.
+- **Experimental** features: hook-based compaction detection and adaptive context learning.
+
+Languages present: Rust (primary), TOML, Markdown, shell, SQL, YAML, JSON.
+Notable dependencies: `serde`/`serde_json`, `rusqlite` (bundled SQLite), `clap`, `chrono`,
+`toml`, `thiserror`, `regex`, `dirs`, `fs2`, `log`/`env_logger`, `sha2`, `hostname`; optional
+`libsql` + `tokio` for the `turso-sync` feature.
+
+## Architectural layers
+
+The knowledge graph organizes the repository into 10 layers:
+
+| Layer | Node count | What it contains |
+|---|---:|---|
+| Application & Entry | 4 | `main.rs`, `lib.rs`, `hook_handler.rs`, `build.rs` |
+| Rendering & Display | 20 | `display.rs`, `theme.rs`, `layout/*`, `themes/*.toml`, `templates/default.tmpl` |
+| Domain & Stats | 11 | `stats/*`, `models.rs`, `context_learning.rs`, `state.rs`, `common.rs` |
+| Persistence & Sync | 21 | `database/*`, `migrations/*`, `sync.rs`, `retry.rs`, Turso schema SQL + table nodes |
+| Git Integration | 3 | `git.rs`, `git_provider.rs`, `git_utils.rs` |
+| Provider & GSD Integrations | 9 | `provider/*`, `gsd/*` |
+| Configuration & Foundations | 9 | `config.rs`, `error.rs`, `version.rs`, `utils.rs`, `Cargo.toml`, `deny.toml`, `VERSION` |
+| CI/CD & Build | 53 | 6 GitHub Actions workflows + jobs, `Makefile` + targets, install/release shell scripts |
+| Tests & Examples | 34 | `tests/*` integration/property/regression tests, `examples/*` Turso programs |
+| Documentation | 17 | root + `docs/*.md`, `NOTICE` |
+
+## Major modules
+
+| Module | Path | Responsibility |
+|---|---|---|
+| **Entry / orchestration** | `src/main.rs`, `src/lib.rs`, `src/hook_handler.rs` | CLI binary, public library API, Claude Code hook handling |
+| **Rendering & display** | `src/display.rs`, `src/theme.rs`, `src/layout/` (`format`, `presets`, `template`, `variables`, `mod`) | Assembles the status-line string; themes, presets, custom templates |
+| **Domain & stats** | `src/stats/` (`aggregation`, `cache`, `persistence`, `session`, `provider`, `mod`), `src/models.rs`, `src/context_learning.rs`, `src/state.rs` | Cost / burn-rate / context math, session state, adaptive learning |
+| **Persistence & sync** | `src/database/` (`schema`, `session`, `daily`, `monthly`, `analytics`, `maintenance`, `sync`, `mod`), `src/migrations/`, `src/sync.rs`, `src/retry.rs` | SQLite store, versioned migrations, optional Turso cloud sync, retry logic |
+| **Git integration** | `src/git.rs`, `src/git_provider.rs`, `src/git_utils.rs` | Branch and working-tree status |
+| **Provider & GSD** | `src/provider/` (`mod`, `test_provider`), `src/gsd/` (`roadmap`, `todos`, `state`, `config`, `update`, `mod`) | `DataProvider` trait + orchestrator; reads `.planning/` GSD project state |
+| **Configuration & foundations** | `src/config.rs`, `src/common.rs`, `src/error.rs`, `src/utils.rs`, `src/version.rs` | TOML config, shared helpers, unified error type, version info |
+
+## Key entry points
+
+- **`src/main.rs`** (≈1,824 lines) — the `statusline` binary. Parses CLI args (clap),
+  reads session JSON from stdin, orchestrates stats/git/rendering, prints the line.
+  Declared in `Cargo.toml` as `[[bin]] name = "statusline"`.
+- **`src/lib.rs`** — library root (`[lib] name = "statusline"`). Public embedding API,
+  exercised by the programs under `examples/`.
+- **`src/hook_handler.rs`** — Claude Code hook entry path (experimental real-time
+  compaction detection).
+- **`build.rs`** — Cargo build script; reads `VERSION` (a `configures` edge `VERSION → build.rs`
+  is recorded in the graph).
+
+## Important dependency relationships
+
+Most depended-on `src/` files, measured by inbound `imports` / `depends_on` / `calls` edges in
+the graph (rolled up to the containing file):
+
+| File | Inbound edges | Notes |
+|---|---:|---|
+| `src/common.rs` | 14 | Shared helpers (e.g. data-dir resolution) — foundational hub |
+| `src/error.rs` | 14 | Unified `thiserror`-based error type — foundational hub |
+| `src/provider/mod.rs` | 8 | `DataProvider` trait + orchestrator; the extension seam |
+| `src/config.rs` | 7 | TOML configuration consumed across modules |
+| `src/database/mod.rs` | 6 | SQLite database façade |
+| `src/utils.rs` | 6 | General utilities (incl. terminal-output sanitization) |
+| `src/retry.rs` | 5 | Retry helper used by git/sync paths |
+| `src/models.rs` | 5 | Session data models (serde) |
+| `src/git.rs` | 5 | Git status collection |
+| `src/gsd/roadmap.rs` | 5 | GSD roadmap parsing |
+
+Structural facts recorded in the graph:
+
+- The `DataProvider` trait in `src/provider/mod.rs` is implemented by `GsdProvider`
+  (`src/gsd/mod.rs`), `StatsProvider` (`src/stats/provider.rs`), and `TestProvider`
+  (`src/provider/test_provider.rs`); `ProviderOrchestrator` `depends_on` `DataProvider`.
+- `src/database/mod.rs::new` calls `migrations::run_migrations_on_db`; `stats` session
+  updates call into `database/session`; maintenance calls `common::get_data_dir`.
+- `scripts/setup-turso-schema.sql` is applied by `scripts/setup-turso.sh` (`migrates` edge).
+- `src/lib.rs` has no internal inbound import edges — expected for a crate root.
+
+### Request / data flow
+
+```
+stdin JSON ──► src/main.rs (clap args + parse)
+   ├─► src/models.rs (deserialize session payload)
+   ├─► src/stats/ (cost, burn rate, context %) ◄──► src/database/ (SQLite read/write, migrations)
+   ├─► src/git.rs / src/git_utils.rs (branch + changes)
+   ├─► src/provider/ orchestrator ──► src/gsd/ (.planning state), stats provider
+   └─► src/display.rs (assemble segments)
+          └─► src/theme.rs + src/layout/ (preset/template + variables) ──► themes/*.toml
+   ──► stdout: rendered status line
+```
+
+Optional/secondary paths: `src/sync.rs` pushes stats to Turso when the `turso-sync` feature is
+enabled; `src/hook_handler.rs` provides a separate fast path for compaction hook events.
+
+## Test locations
+
+- **`tests/`** — integration tests, including burn-rate scenarios (accumulation, auto-reset,
+  long sessions, multi-day wall clock), `sqlite_integration_tests.rs`, `theme_integration.rs`,
+  `layout_integration_tests.rs`, `display_config_integration.rs`, `hook_integration_tests.rs`,
+  `lib_api_tests.rs`, `context_tokens_display_tests.rs`, `db_maintenance_tests.rs`,
+  `regression_tests.rs`, and property tests in `proptest_tests.rs`
+  (seeds in `proptest_tests.proptest-regressions`).
+  - **`tests/test_support.rs`** is the shared test harness, imported by 21 of the integration
+    test files — the central test-support node in the graph.
+- **Inline module tests** — `src/database/tests.rs`, `src/stats/tests.rs`, `src/gsd/tests.rs`,
+  `src/layout/tests.rs`, and the mock in `src/provider/test_provider.rs`.
+- **`examples/`** — `setup_schema`, `inspect_turso_data`, `check_turso_version`,
+  `migrate_turso`, `embedding_example`. The Turso examples are gated by the `turso-sync`
+  feature (per `Cargo.toml`).
+
+## Build / run commands
+
+From the `Makefile` (targets present: `all build debug release install uninstall clean
+test test-sqlite test-install test-all test-manual clean-test show-db-path check check-code
+dev bench version bump-major bump-minor bump-patch tag size lint fmt release-build`):
+
+| Command | Effect |
+|---|---|
+| `make` / `make build` | Build the release binary |
+| `make debug` | Build debug binary with symbols |
+| `make release` | Build optimized release binary |
+| `make install` | Build and install to `~/.local/bin` |
+| `make test` | Run unit and integration tests |
+| `make test-sqlite` | Run SQLite integration tests |
+| `make test-all` | Run all tests |
+| `make test-manual` | Run against an isolated test database |
+| `make check-code` | Run `rustfmt` and `clippy` |
+| `make dev` | Build and run with test input |
+| `make bench` | Run a performance benchmark |
+| `make show-db-path` | Show production vs test database paths |
+
+Direct Cargo equivalents (standard for this crate layout):
+
+- `cargo build --release` — build the `statusline` binary.
+- `cargo test` — run the test suite.
+- `cargo build --release --features turso-sync` — build with optional Turso cloud sync.
+
+Quick install (from `README.md`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hagan/claudia-statusline/main/scripts/quick-install.sh | bash
+```
+
+Install/release tooling lives in `scripts/` (`install-statusline.sh`, `quick-install.sh`,
+`uninstall-statusline.sh`, `release.sh`, `bump-version.sh`, `maintenance.sh`,
+`setup-turso.sh`, `setup-turso-schema.sql`, `toggle-debug.sh`, `test-installation.sh`).
+CI is defined under `.github/workflows/` (`build`, `test`, `security`, `release-v2`,
+`test-binaries`, `test-binaries-fixed`).
+
+> Note: the `Makefile`'s `SOURCES` variable lists a flat file set
+> (`src/stats.rs`, etc.) that predates the current module-directory layout
+> (`src/stats/`, `src/database/`, `src/layout/`, `src/gsd/`). The build targets themselves
+> use Cargo and are unaffected; the variable is recorded here only for accuracy.
+
+## Risky or central files
+
+These stand out by fan-in (blast radius) and/or size. Listed as observations, not
+recommendations.
+
+- **`src/error.rs`** and **`src/common.rs`** — highest fan-in (14 inbound edges each).
+  Changes to the error type or shared helpers ripple across most of the codebase.
+- **`src/main.rs`** (≈1,824 lines) — large, central orchestration with significant branching.
+- **`src/config.rs`** (≈1,638 lines, fan-in 7) — wide configuration surface; relates to both
+  in-memory consumers and serialized TOML compatibility.
+- **`src/database/` + `src/migrations/`** — persistent state. `src/migrations/mod.rs`
+  (≈830 lines) and `src/database/schema.rs` carry versioned DDL applied to existing SQLite
+  stores; this is the data-integrity hotspot.
+- **`src/sync.rs`** (≈772 lines) + Turso — networked, feature-gated, experimental; the hardest
+  paths to exercise deterministically.
+- **`src/display.rs`** (≈1,412 lines), **`src/layout/variables.rs`** (≈848 lines),
+  **`src/theme.rs`** (≈865 lines) — the rendering surface, where 11 themes × 5 presets ×
+  templates create a large output-combination space (covered by `src/layout/tests.rs`,
+  ≈2,066 lines, and theme integration tests).
+- **`src/provider/mod.rs`** (≈769 lines, fan-in 8) — the trait/orchestrator seam that the
+  GSD/stats/test providers depend on.
+
+---
+
+*Largest files by line count (from the scan inventory):* `src/layout/tests.rs` (2,066),
+`src/main.rs` (1,824), `src/gsd/tests.rs` (1,800), `src/config.rs` (1,638),
+`src/display.rs` (1,412), `src/utils.rs` (1,348), `src/database/tests.rs` (1,119),
+`src/context_learning.rs` (1,004), `src/stats/tests.rs` (917), `src/theme.rs` (865).

--- a/docs/architecture/risky-areas.md
+++ b/docs/architecture/risky-areas.md
@@ -1,0 +1,162 @@
+# Risky Areas — Claudia Statusline
+
+> **Source:** Derived from `.understand-anything/knowledge-graph.json` (575 nodes, 767 edges)
+> at commit `ac29509`, cross-checked against the source tree. Connectivity = inbound + outbound
+> dependency-type edges (`imports`, `depends_on`, `calls`, `implements`, `configures`,
+> `tested_by`), rolled up to the containing file.
+>
+> This document flags areas that warrant care. It is descriptive only — it records risk signals
+> and does **not** prescribe code changes. Companion docs:
+> `docs/architecture/project-map.md`, `docs/architecture/key-flows.md`.
+
+---
+
+## 1. Highly connected files (high blast radius)
+
+Ranked by total degree. High fan-**in** = many callers depend on it (changes ripple outward);
+high fan-**out** = it orchestrates many modules (easy to break by changing a dependency).
+
+| File | Degree | Fan-in | Fan-out | LOC | Why it's risky |
+|---|---:|---:|---:|---:|---|
+| `src/main.rs` | 22 | 0 | 22 | 1,824 | Binary orchestrator; wires together every subsystem. Large + branch-heavy. |
+| `src/lib.rs` | 22 | 0 | 22 | 312 | Public library API (`render_statusline`); mirrors `main` and re-exports modules. Drift between the two is a recurring hazard. |
+| `src/gsd/mod.rs` | 17 | 3 | 14 | 458 | `GsdProvider` reaches across all GSD submodules; high fan-out into roadmap/state/todos/update. |
+| `src/database/mod.rs` | 16 | 6 | 10 | 215 | SQLite façade (`SqliteDatabase`); central to all persistence and triggers migrations on open. |
+| `src/common.rs` | 15 | **14** | 1 | 264 | Foundational helpers (data-dir, device id, dates). 14 modules depend on it — a signature change ripples broadly. |
+| `src/error.rs` | 14 | **14** | 0 | 104 | Unified `StatuslineError` type. Touched by nearly everything; changing a variant breaks many call sites. |
+| `src/provider/mod.rs` | 13 | 11 | 2 | 769 | `DataProvider` trait + `ProviderOrchestrator` — the extension seam every provider implements. |
+| `src/stats/mod.rs` | 12 | 4 | 8 | 84 | Thin re-export hub for the stats submodules; small but widely referenced. |
+| `src/git.rs` | 9 | 5 | 4 | 700 | Git status parsing (two porcelain paths). External-process output parsing = fragile inputs. |
+| `src/utils.rs` | 9 | 6 | 3 | 1,348 | Grab-bag utilities incl. transcript parsing + terminal sanitization. Large and broadly used. |
+| `src/config.rs` | 9 | 7 | 2 | 1,638 | Wide config surface (18 config structs); also governs serialized TOML compatibility. |
+
+**Top two hubs to treat as load-bearing:** `src/error.rs` and `src/common.rs` (fan-in 14 each).
+Any change to their public surface should be assumed to affect most of the codebase.
+
+---
+
+## 2. Modules with unclear / split ownership
+
+These are places where a single concept is spread across multiple files, so "where does this
+logic belong?" is genuinely ambiguous and easy to get wrong.
+
+- **Session state is owned in three places.**
+  `src/stats/session.rs` (`SessionStats`, in-memory `update_session`),
+  `src/database/session.rs` (SQL `update_session` / `update_session_tx`), and
+  `src/database/schema.rs` (`SessionUpdate` struct). The flow constructs a `SessionUpdate` in
+  `lib.rs`/`main.rs`, but `active_time_seconds` / `last_activity` are deliberately computed
+  *inside* `SqliteDatabase::update_session` and left `None` at the construction site (noted in
+  the source as a v3.0.0 cleanup). The ownership boundary is subtle and undocumented at the type level.
+
+- **Persistence is split between `src/stats/` and `src/database/`.**
+  `src/stats/persistence.rs` (`update_stats_data`, `load_from_sqlite`, `migrate_to_sqlite`,
+  `perform_sqlite_dual_write`) sits on top of `src/database/*`. Two surfaces both legitimately
+  claim "persist stats," and the load path has legacy-JSON fallback logic that is easy to
+  regress (see §4).
+
+- **Provider logic is spread across three locations.**
+  `src/provider/mod.rs` (trait + orchestrator), `src/stats/provider.rs` (`StatsProvider`),
+  `src/gsd/mod.rs` (`GsdProvider`), plus `src/provider/test_provider.rs`. Adding or reordering
+  providers touches multiple files with no single registry-of-record beyond
+  `ProviderOrchestrator::register`.
+
+- **`src/utils.rs` (1,348 LOC) is a catch-all.** It mixes transcript token parsing, terminal
+  sanitization, and misc helpers with fan-in 6. Unclear ownership makes it a magnet for
+  unrelated additions.
+
+---
+
+## 3. Duplicated-looking responsibilities (name collisions / repeated patterns)
+
+These are not necessarily bugs — several are intentional layering — but the **collisions make it
+easy to edit the wrong file** or assume the wrong behavior.
+
+| Symbol / file | Locations | Note |
+|---|---|---|
+| `update_session` | `src/stats/session.rs` **and** `src/database/session.rs` | Same name, different layers; the stats one delegates to the database one. Easy to confuse which to change. |
+| `sync.rs` | `src/sync.rs` (Turso cloud sync, `SyncManager`) **and** `src/database/sync.rs` (DB-level sync) | Two unrelated "sync" files. |
+| `config.rs` | `src/config.rs` (app config) **and** `src/gsd/config.rs` (GSD config) | Two distinct config systems sharing a filename. |
+| `state.rs` | `src/state.rs` **and** `src/gsd/state.rs` | Two distinct "state" concepts. |
+| `fill_vars` | `src/gsd/{roadmap,state,todos,update}.rs` (4×) | Repeated provider-fill pattern duplicated per submodule rather than abstracted. |
+| `read_with_cache` | `src/gsd/{roadmap,state,update}.rs` (3×) | Same caching pattern reimplemented in three GSD submodules. |
+| `new` / `collect` | `database/mod.rs` & `stats/provider.rs` / `provider/test_provider.rs` & `stats/provider.rs` | Provider/constructor conventions repeated across the abstraction. |
+
+> The install/uninstall shell scripts also duplicate helpers (`detect_config_file`,
+> `validate_path`, `install_binary`, `configure_claude`, `usage`, `print_summary`) across
+> `scripts/install-statusline.sh`, `scripts/quick-install.sh`, and `scripts/uninstall-statusline.sh`.
+> Lower stakes (not shipped in the binary), but the same logic exists in multiple copies.
+
+---
+
+## 4. Places where changes need extra tests
+
+> **Coverage signal caveat:** the graph contains **no surviving `tested_by` edges for `src/`
+> production files** — coverage is via inline `*/tests.rs` modules and `tests/` integration
+> tests rather than explicit links. So the items below are flagged by data sensitivity and
+> blast radius, and the named test files are where regressions would surface.
+
+- **Migrations & schema** — `src/migrations/mod.rs` (`MigrationRunner`, `Migration::migrate`,
+  `run_migrations_on_db`) and `src/database/schema.rs`. Versioned DDL applied to *existing*
+  user databases; a bad change can corrupt or block live SQLite stores. Exercise
+  `tests/sqlite_integration_tests.rs` and `tests/db_maintenance_tests.rs`.
+- **Stats load/dual-write path** — `src/stats/persistence.rs::update_stats_data` and
+  `perform_sqlite_dual_write`. The legacy `stats.json` → SQLite migration fallback (using
+  `load()` instead of `default()`) exists specifically to avoid wiping v2.x history; regressions
+  here are silent data loss. Covered by `tests/sqlite_integration_tests.rs`,
+  `tests/integration_tests.rs`, `src/stats/tests.rs`, `src/database/tests.rs`.
+- **Burn-rate & active-time math** — `src/stats/session.rs`, `src/database/session.rs`
+  (`get_session_active_time`). Already backed by a large dedicated suite
+  (`tests/burn_rate_*` — accumulation, auto-reset, long gaps, multi-day wall clock, high
+  volume); any change to the accounting must keep those green.
+- **Rendering surface** — `src/display.rs` (1,412 LOC), `src/layout/variables.rs` (848 LOC),
+  `src/theme.rs`, and the `src/layout/` template engine. 11 themes × 5 presets × custom
+  templates is a large output-combination space. Covered by `tests/theme_integration.rs`,
+  `tests/layout_integration_tests.rs`, `tests/display_config_integration.rs`, and the
+  2,066-line `src/layout/tests.rs`.
+- **Git status parsing** — `src/git.rs` (`parse_git_status`, `parse_git_status_v2`,
+  `apply_status_codes`). Parses external `git` output (two porcelain formats, one behind the
+  `git_porcelain_v2` feature); fragile to format/locale variation.
+- **Context / compaction detection** — `src/context_learning.rs` (`ContextLearner`) and
+  `src/hook_handler.rs`. Experimental, stateful, timing-sensitive. Covered by
+  `tests/context_learning_sanitization_tests.rs`, `tests/context_tokens_display_tests.rs`,
+  `tests/hook_integration_tests.rs`.
+- **Config surface** — `src/config.rs`. Adding/renaming fields affects deserialization of
+  user-authored TOML; check `tests/baseline_config_test.rs` and `tests/display_config_integration.rs`.
+- **Cloud sync** — `src/sync.rs` (`SyncManager`, `resolve_auth_token`). Feature-gated
+  (`turso-sync`), networked, hardest to test deterministically; auth-token resolution handles
+  `${VAR}`/`$VAR`/literal forms.
+
+---
+
+## 5. Areas GSD should inspect before modifying
+
+A pre-edit checklist for `/gsd:plan`-style work, ordered by blast radius:
+
+1. **`src/error.rs` and `src/common.rs`** — fan-in 14 each. Inspect all callers before changing
+   any public signature; assume codebase-wide impact.
+2. **`src/main.rs` ↔ `src/lib.rs`** — the binary and library duplicate the stats-update +
+   render logic. A change in one almost always needs the mirror change in the other; verify both
+   plus `tests/lib_api_tests.rs`.
+3. **Persistence stack** (`src/stats/persistence.rs` → `src/database/*` → `src/migrations/`) —
+   any schema, migration, or load-path change is a data-integrity event on live SQLite stores.
+   Confirm the legacy-JSON fallback still migrates, and add/extend migration tests.
+4. **Session ownership** (`stats/session.rs`, `database/session.rs`, `database/schema.rs`) —
+   before touching session fields, confirm which layer owns the field (notably `active_time_seconds`
+   / `last_activity`, computed in the DB layer).
+5. **Provider seam** (`src/provider/mod.rs` + `src/stats/provider.rs` + `src/gsd/mod.rs`) — adding
+   data sources or variables touches the trait, the orchestrator registration, and possibly the
+   GSD `fill_vars` duplication. Inspect all four GSD submodules that implement `fill_vars`.
+6. **Name-collision files** (`sync.rs`, `config.rs`, `state.rs`, `session.rs` — each appears in
+   two locations) — verify you are editing the intended file/layer; grep by full path, not base name.
+7. **Rendering** (`display.rs`, `layout/`, `theme.rs`) — re-run the theme/layout/display
+   integration suites; output regressions are easy and not always obvious.
+8. **External-input parsers** (`src/git.rs`, transcript parsing in `src/utils.rs`) — fragile to
+   upstream format changes; treat inputs as untrusted.
+9. **`.planning/` is a symlink** to an external secure mount (`~/mnt/claudia-docs-secure/.planning`),
+   shared GSD state — not a normal in-repo directory. Don't assume it's local or writable in CI.
+
+---
+
+*Connectivity and duplication figures above are reproducible from
+`.understand-anything/knowledge-graph.json`. See `project-map.md` for the full module map and
+`key-flows.md` for the call sequences referenced here.*


### PR DESCRIPTION
Closes #37. Repo hygiene via GSD `/gsd:quick`. No Rust source changes.

## Changes
1. **`.gitignore`** — ignore `.understand-anything/` (generated knowledge-graph tooling output: large JSON + dashboard cache; regenerate with `/understand`).
2. **`docs/architecture/`** — committed the hand-curated docs `project-map.md`, `key-flows.md`, `risky-areas.md` as intentional repo documentation (decision: keep the docs, ignore only the generator's output). These complement the ARCHITECTURE.md refresh tracked in #40.
3. **`Makefile`** — removed the stale, unused `SOURCES` variable (it listed `src/stats.rs`, now a directory; no target consumed `$(SOURCES)`).

## Note on the .bak file
The issue listed `config.toml.local.bak` as committed, but it's **already untracked** (`*.bak` is in `.gitignore`) — verified, no action needed.

## Verification
- `git status` is now clean (the two untracked dirs that polluted it are resolved).
- `cargo build` OK; `cargo fmt --all -- --check` clean.
- No source changed, so a full clippy/test cycle isn't required for a gitignore/Makefile/docs change.