### PR TITLE
Docs refresh: v3.0.0 layout, retire SQLITE_MIGRATION.md, document release process (#40)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,23 +4,30 @@
 Claudia Statusline is a Rust CLI and embeddable library that renders a richer status line for Claude Code sessions. The binary ingests JSON over stdin, enriches it with git and persistent usage data, and writes a pre-formatted line to stdout. The workspace keeps shared logic under `src/lib.rs` so the CLI and library can share the same building blocks.
 
 ## Workspace Layout
+> v3.0.0 reorganised several single-file modules into directories. See
+> `docs/architecture/project-map.md` for the full per-file module map.
+
 - `src/main.rs` – CLI entry point, Clap command definitions, high level orchestration
 - `src/lib.rs` – public API surface for embedding (`render_statusline`, `render_from_json`)
+- `src/render.rs` – shared stats-update + render flow used by both `main.rs` and `lib.rs`
 - `src/common.rs` – helpers for timestamps, device IDs, and path discovery (XDG locations)
 - `src/config.rs` – configuration loading/merging, defaults, retry settings, theme resolution
 - `src/context_learning.rs` – adaptive context window learning (experimental, opt-in)
-- `src/database.rs` – SQLite backend (schema creation, CRUD helpers, maintenance utilities)
+- `src/database/` – SQLite backend module (schema, session/daily/monthly CRUD, analytics, maintenance, sync, `mod`)
 - `src/display.rs` – formatting helpers, color palette, context bar rendering
 - `src/error.rs` – shared error type built on `thiserror`
-- `src/git.rs` / `src/git_utils.rs` – git status collection with timeout-aware subprocess helpers
+- `src/git.rs` / `src/git_utils.rs` / `src/git_provider.rs` – git status collection (timeout-aware subprocess) and its provider wrapper
+- `src/gsd/` – GSD project-tracking provider (roadmap, todos, state, config, update, `mod`)
+- `src/layout/` – layout engine for presets and custom templates (format, presets, template, variables, `mod`)
 - `src/models.rs` – serde-ready data structures for JSON input and transcripts
+- `src/migrations/` – migration framework for evolving the local schema
+- `src/provider/` – `DataProvider` trait and `ProviderOrchestrator` (parallel data collection)
 - `src/retry.rs` – reusable retry/backoff primitives for transient failures
-- `src/stats.rs` – persistent stats tracking (JSON fallback, SQLite primary store)
+- `src/stats/` – persistent stats tracking module (aggregation, cache, persistence, session, provider, `mod`); SQLite-only since v3.0.0 with one-shot legacy-JSON recovery
 - `src/theme.rs` – theme system with TOML-based configuration and color resolution
 - `src/utils.rs` – path shortening, input sanitisation, transcript parsing, duration helpers
 - `src/version.rs` – build metadata exposed through `--version` and library helpers
 - `src/sync.rs` – cloud sync implementation (compiled when the `turso-sync` feature is enabled)
-- `src/migrations/mod.rs` – migration framework for evolving the local schema
 
 Tests live alongside the binary in `tests/` (`integration_tests.rs`, `sqlite_integration_tests.rs`, `db_maintenance_tests.rs`, `lib_api_tests.rs`, `proptest_tests.rs`). Examples for the sync feature are under `examples/`.
 
@@ -31,16 +38,16 @@ graph TD
     B --> C[models.rs - parse input]
     B --> D[git.rs - collect repo status]
     C --> E{Has cost + session?}
-    E -->|yes| F[stats.rs - update aggregates]
-    F --> G[database.rs - persist to SQLite]
-    E -->|no| H[stats.rs - load cached totals]
+    E -->|yes| F[stats module - update aggregates]
+    F --> G[database module - persist to SQLite]
+    E -->|no| H[stats module - load cached totals]
     G --> I[display.rs]
     H --> I
     D --> I
     I --> J[stdout]
 ```
 
-When compiled with `turso-sync`, the optional sync subcommand pulls data from `stats.rs`/`database.rs`, performs network I/O via `sync.rs`, and merges results back through the same persistence layer.
+When compiled with `turso-sync`, the optional sync subcommand pulls data from the `stats`/`database` modules, performs network I/O via `sync.rs`, and merges results back through the same persistence layer.
 
 ## Key Design Choices
 - **Safe Rust only** – the crate avoids `unsafe` blocks, favouring explicit `Result` flows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,16 +104,53 @@ make lint         # Run clippy linter
 make clean        # Clean build artifacts
 ```
 
+### Cutting a Release
+
+Published release artifacts are built and uploaded by the **`release` GitHub Actions
+workflow** (`.github/workflows/release.yml`), which triggers on pushing a `v*` tag. That
+workflow is the source of truth for what ships; the local scripts/targets below are for
+bumping the version and preparing/sanity-checking the tag.
+
+Blessed path:
+
+```bash
+# 1. Bump the version (edits VERSION + Cargo.toml and related references)
+make bump-patch          # or: make bump-minor / make bump-major
+#    (equivalently: ./scripts/bump-version.sh patch)
+
+# 2. Commit the bump through the normal branch -> PR -> main flow, and update CHANGELOG.md.
+
+# 3. From an up-to-date main, create the annotated tag (reads VERSION):
+make tag                 # creates vX.Y.Z
+
+# 4. Push the tag — this is what fires the release workflow:
+git push origin "v$(cat VERSION)"     # or: git push --tags
+```
+
+Notes:
+- `scripts/release.sh` is an optional local helper that creates the tag and builds a local
+  Linux tarball for spot-checking; the multi-platform artifacts attached to the GitHub
+  Release still come from `release.yml`.
+- `make release-build` just does a clean local `--release` build + `--version` check; it does
+  not tag or publish.
+- The version lives in `VERSION` and `Cargo.toml`; `build.rs` reads `VERSION` so they must
+  agree. `make bump-*` keeps them in sync — don't edit them by hand.
+
 ### Code Organization
 
-The codebase is organized into focused modules:
+The codebase is organized into focused modules (v3.0.0 moved several into
+directories — see `docs/architecture/project-map.md` for the full map):
 
 - `main.rs` - Entry point, CLI parsing, orchestration
+- `lib.rs` / `render.rs` - Embedding API and the shared stats-update + render flow
 - `models.rs` - Data structures and types
-- `stats.rs` - Statistics tracking (SQLite-first with JSON backup)
-- `database.rs` - SQLite operations
-- `display.rs` - Output formatting and colors
-- `git.rs` - Git repository operations
+- `stats/` - Statistics tracking module (SQLite-only since v3.0.0)
+- `database/` - SQLite operations module (schema, CRUD, maintenance, sync)
+- `migrations/` - Schema migration framework
+- `display.rs` / `theme.rs` / `layout/` - Output formatting, colors, and the layout/template engine
+- `git.rs` / `git_utils.rs` / `git_provider.rs` - Git repository operations
+- `gsd/` - GSD project-tracking data provider
+- `provider/` - `DataProvider` trait and parallel `ProviderOrchestrator`
 - `utils.rs` - Utility functions
 - `config.rs` - Configuration management
 - `error.rs` - Error handling

--- a/SQLITE_MIGRATION.md
+++ b/SQLITE_MIGRATION.md
@@ -1,8 +1,13 @@
 # SQLite Migration Guide
 
+> **⚠️ Historical document.** The JSON→SQLite migration described here **completed in
+> v3.0.0** — SQLite is the only storage backend and JSON writing was removed. This file is
+> retained for historical context (the phased rollout plan below). For current behavior and
+> legacy-data recovery, see **[MIGRATION_GUIDE.md](MIGRATION_GUIDE.md)**.
+
 ## Overview
 
-Claudia Statusline is migrating from JSON to SQLite for improved performance and concurrent access support. This is happening in three phases to ensure zero downtime and no data loss.
+Claudia Statusline migrated from JSON to SQLite for improved performance and concurrent access support. This happened in three phases to ensure zero downtime and no data loss. All three phases are now complete (as of v3.0.0).
 
 ## Migration Phases
 
@@ -12,13 +17,13 @@ Claudia Statusline is migrating from JSON to SQLite for improved performance and
 - All writes go to both storage backends
 - No user action required
 
-### Phase 2: SQLite-First (v2.7.0+) ✅ CURRENT
+### Phase 2: SQLite-First (v2.7.0+) ✅ COMPLETE
 - **SQLite-first reads with JSON backup writes**
 - Automatic migration from JSON on first run
 - JSON maintained as backup/compatibility layer
 - Zero configuration needed - fully automatic
 
-### Phase 3: SQLite Only (v3.0.0) ✅ READY
+### Phase 3: SQLite Only (v3.0.0) ✅ COMPLETE (shipped)
 - JSON backup can now be disabled with config option
 - Use `statusline migrate --finalize` to complete migration
 - SQLite becomes the only storage backend


### PR DESCRIPTION
Closes #40. Docs-only refresh via GSD `/gsd:quick`; every claim verified against the real tree/scripts.

## Changes (3 atomic commits)

1. **`ARCHITECTURE.md`** — the Workspace Layout + Data Flow sections still described the pre-3.0 **flat** layout (`src/database.rs`, `src/stats.rs`). Updated to the v3.0.0 **module directories** (`database/`, `stats/`, `gsd/`, `layout/`, `provider/`, `migrations/`), added the new `src/render.rs` and `git_provider.rs`, corrected the stale "JSON fallback" note (SQLite-only since v3.0.0), and pointed to `docs/architecture/project-map.md` for the full map.
2. **`SQLITE_MIGRATION.md`** — added a clear **historical banner** pointing to the current `MIGRATION_GUIDE.md`, and fixed stale phase markers (Phase 2 "CURRENT" → COMPLETE, Phase 3 "READY" → COMPLETE/shipped). Kept the file in place rather than deleting/moving — the only CHANGELOG mention is a past-tense historical entry (no live link), and the phased-rollout record is worth preserving.
3. **`CONTRIBUTING.md`** — fixed the same stale flat-module list in "Code Organization", and added a **"Cutting a Release"** section documenting the single blessed path: `make bump-*` → PR → `make tag` → push tag (which fires `release.yml`). Clarifies that `release.yml` is the source of truth and `bump-version.sh` / `release.sh` / Makefile targets are prep helpers — resolving #40's "overlapping release mechanisms documented nowhere" point.

## Verification
- Grep confirms no stale `src/stats.rs` / `src/database.rs` flat-module references remain.
- The documented release flow matches the actual `scripts/bump-version.sh`, `scripts/release.sh`, Makefile `bump-*`/`tag`/`release-build` targets, and the `release.yml` `push: tags: v*` trigger (all read directly).
- Docs-only — no source/build impact.