### PR TITLE
Unit-test coverage for high-value gaps: legacy-JSON migration, active-time calc, VariableBuilder (#38)

### DIFF
--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -1057,6 +1057,207 @@ fn test_active_time_ignores_long_gaps() {
     );
 }
 
+// =============================================================================
+// P2 (issue #38): active-time CALCULATION coverage of update_session_tx.
+//
+// The two STORAGE tests above (test_active_time_accumulation /
+// test_active_time_ignores_long_gaps) explicitly manually-set active_time_seconds and
+// defer the automatic CALCULATION branch (session.rs:350-408) to out-of-process
+// integration tests. These tests fill that gap at the UNIT level by driving the real
+// calculation: set STATUSLINE_BURN_RATE_MODE=active_time + threshold, reset_config(),
+// then SQL-backdate last_activity to simulate inter-update gaps (NO thread::sleep).
+//
+// All four mutate process-global config, so each is #[serial] and restores the env +
+// reset_config() at the end. update_session_tx is private; we exercise it via the
+// public update_session (inline tests have crate access — no visibility widening).
+//
+// Tolerance: the calc is wall-clock now minus the backdated stored timestamp, so the
+// measured gap = backdated_seconds + tiny_execution_delta. We assert a small RANGE,
+// which is deterministic and non-flaky without sleeps.
+// =============================================================================
+
+/// Helper: backdate last_activity to `secs_ago` seconds before now via raw SQL.
+/// Mirrors tests/burn_rate_support.rs::backdate_last_activity_secs.
+fn backdate_last_activity(conn: &Connection, id: &str, secs_ago: i64) {
+    let ts = (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339();
+    conn.execute(
+        "UPDATE sessions SET last_activity = ?1 WHERE session_id = ?2",
+        rusqlite::params![ts, id],
+    )
+    .unwrap();
+}
+
+/// Spell out the full 10-field SessionUpdate literal (matching the surrounding style)
+/// with only cost set; everything else None so the active_time branch keys off config
+/// and the stored last_activity, not the update struct.
+fn cost_only_update(cost: f64) -> SessionUpdate {
+    SessionUpdate {
+        cost,
+        lines_added: 0,
+        lines_removed: 0,
+        model_name: None,
+        workspace_dir: None,
+        device_id: None,
+        token_breakdown: None,
+        max_tokens_observed: None,
+        active_time_seconds: None,
+        last_activity: None,
+    }
+}
+
+fn read_active_time(conn: &Connection, id: &str) -> Option<i64> {
+    conn.query_row(
+        "SELECT active_time_seconds FROM sessions WHERE session_id = ?1",
+        rusqlite::params![id],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+#[test]
+#[serial_test::serial]
+fn test_active_time_calc_adds_gap_below_threshold() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db = SqliteDatabase::new(&db_path).unwrap();
+
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "active_time");
+    std::env::set_var("STATUSLINE_BURN_RATE_THRESHOLD", "30"); // 30 minutes
+    crate::config::reset_config();
+
+    let id = "calc-below-threshold";
+
+    // First update: first-update branch -> active_time becomes 0, last_activity = now.
+    db.update_session(id, cost_only_update(1.0)).unwrap();
+
+    // Backdate last_activity to 120s ago (well below the 30-min threshold).
+    let conn = Connection::open(&db_path).unwrap();
+    backdate_last_activity(&conn, id, 120);
+
+    // Second update: gap of ~120s should be ADDED to active_time.
+    db.update_session(id, cost_only_update(2.0)).unwrap();
+
+    let active_time = read_active_time(&conn, id).expect("active_time should be set");
+    assert!(
+        (120..=124).contains(&active_time),
+        "120s gap (below threshold) should be added to active_time; got {}",
+        active_time
+    );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    std::env::remove_var("STATUSLINE_BURN_RATE_THRESHOLD");
+    crate::config::reset_config();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_active_time_calc_skips_gap_above_threshold() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db = SqliteDatabase::new(&db_path).unwrap();
+
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "active_time");
+    std::env::set_var("STATUSLINE_BURN_RATE_THRESHOLD", "30"); // 30 minutes
+    crate::config::reset_config();
+
+    let id = "calc-above-threshold";
+
+    // First update -> active_time 0.
+    db.update_session(id, cost_only_update(1.0)).unwrap();
+
+    // Backdate last_activity to 1860s ago (31 min, ABOVE the 30-min threshold).
+    let conn = Connection::open(&db_path).unwrap();
+    backdate_last_activity(&conn, id, 1860);
+
+    // Second update: gap exceeds threshold -> NOT added (idle period).
+    db.update_session(id, cost_only_update(2.0)).unwrap();
+
+    let active_time = read_active_time(&conn, id).expect("active_time should be set");
+    assert!(
+        (0..=2).contains(&active_time),
+        "31-min gap (above threshold) should NOT be added to active_time; got {}",
+        active_time
+    );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    std::env::remove_var("STATUSLINE_BURN_RATE_THRESHOLD");
+    crate::config::reset_config();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_active_time_calc_first_update_starts_at_zero() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db = SqliteDatabase::new(&db_path).unwrap();
+
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "active_time");
+    std::env::set_var("STATUSLINE_BURN_RATE_THRESHOLD", "30");
+    crate::config::reset_config();
+
+    let id = "calc-first-update";
+
+    // Single update with no prior activity -> first-update branch (session.rs:396).
+    db.update_session(id, cost_only_update(1.0)).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let active_time = read_active_time(&conn, id);
+    assert_eq!(
+        active_time,
+        Some(0),
+        "first update in active_time mode should start active_time at 0"
+    );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    std::env::remove_var("STATUSLINE_BURN_RATE_THRESHOLD");
+    crate::config::reset_config();
+}
+
+/// P2d: prove the daily aggregate UPSERT runs in the SAME update_session call/transaction
+/// as the session UPSERT (does not duplicate test_aggregates, which covers daily totals
+/// across multiple sessions). Single dedicated assertion: one update writes the daily row
+/// for current_date() with total_cost == the cost delta.
+#[test]
+#[serial_test::serial]
+fn test_update_session_writes_daily_in_same_tx() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db = SqliteDatabase::new(&db_path).unwrap();
+
+    // Run in active_time mode for parity with the other P2 cases; daily aggregation is
+    // mode-independent, but keeping the serial config block consistent avoids bleed.
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "active_time");
+    std::env::set_var("STATUSLINE_BURN_RATE_THRESHOLD", "30");
+    crate::config::reset_config();
+
+    let id = "daily-same-tx";
+    let today = current_date();
+
+    // Single update with a known cost.
+    db.update_session(id, cost_only_update(3.5)).unwrap();
+
+    // The daily_stats row for today must already exist after that single call,
+    // proving the daily UPSERT ran in the same transaction as the session UPSERT.
+    let conn = Connection::open(&db_path).unwrap();
+    let daily_cost: f64 = conn
+        .query_row(
+            "SELECT total_cost FROM daily_stats WHERE date = ?1",
+            rusqlite::params![today],
+            |row| row.get(0),
+        )
+        .expect("daily_stats row for today must be written in the same update_session tx");
+
+    assert!(
+        (daily_cost - 3.5).abs() < 1e-9,
+        "daily total_cost should equal the cost delta from the single update; got {}",
+        daily_cost
+    );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    std::env::remove_var("STATUSLINE_BURN_RATE_THRESHOLD");
+    crate::config::reset_config();
+}
+
 #[test]
 fn test_reset_session_max_tokens() {
     use tempfile::TempDir;

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -856,8 +856,14 @@ fn test_existing_database_permissions_fixed() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_active_time_tracking_storage() {
     use tempfile::TempDir;
+
+    // #38: pin NON-active_time mode + reset_config under #[serial] so the calculation
+    // branch is inert and the P2 calculation tests cannot bleed in under parallelism.
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "wall_clock");
+    crate::config::reset_config();
 
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
@@ -907,9 +913,13 @@ fn test_active_time_tracking_storage() {
     } else {
         panic!("Failed to parse timestamps for comparison");
     }
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    crate::config::reset_config();
 }
 
 #[test]
+#[serial_test::serial]
 fn test_active_time_accumulation() {
     use chrono::{DateTime, Duration, Utc};
     use tempfile::TempDir;
@@ -923,6 +933,12 @@ fn test_active_time_accumulation() {
     //   - tests/burn_rate_active_time_threshold_test.rs (threshold handling)
     // These integration tests use separate processes with STATUSLINE_BURN_RATE_MODE env var
     // to avoid OnceLock config conflicts and properly exercise the automatic calculation path.
+    //
+    // #38: pin a NON-active_time mode + reset_config under #[serial] so the calculation
+    // branch does NOT run (this is a STORAGE test) and so the P2 calculation tests (which
+    // set active_time mode globally) cannot bleed into this test under parallelism.
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "wall_clock");
+    crate::config::reset_config();
 
     // Create database
     let db = SqliteDatabase::new(&db_path).unwrap();
@@ -985,14 +1001,23 @@ fn test_active_time_accumulation() {
         Some(300),
         "Active time should accumulate when messages are close together"
     );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    crate::config::reset_config();
 }
 
 #[test]
+#[serial_test::serial]
 fn test_active_time_ignores_long_gaps() {
     use tempfile::TempDir;
 
     // NOTE: This test manually sets active_time_seconds to test STORAGE, not CALCULATION.
     // The automatic threshold logic is tested in integration tests (see comment in test_active_time_accumulation).
+    //
+    // #38: pin NON-active_time mode + reset_config under #[serial] so the calculation
+    // branch is inert (STORAGE test) and the P2 calculation tests cannot bleed in.
+    std::env::set_var("STATUSLINE_BURN_RATE_MODE", "wall_clock");
+    crate::config::reset_config();
 
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
@@ -1055,6 +1080,9 @@ fn test_active_time_ignores_long_gaps() {
         Some(0),
         "Active time should NOT accumulate across long gaps"
     );
+
+    std::env::remove_var("STATUSLINE_BURN_RATE_MODE");
+    crate::config::reset_config();
 }
 
 // =============================================================================

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -529,15 +529,7 @@ fn test_git_with_config_format_status() {
         color: String::new(),
     };
     let vars = VariableBuilder::new()
-        .git_with_config(
-            "main +2",
-            Some("main"),
-            Some("+2"),
-            true,
-            "",
-            "",
-            &config,
-        )
+        .git_with_config("main +2", Some("main"), Some("+2"), true, "", "", &config)
         .build();
 
     // status format inserts the raw status_only string into "git".

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -447,6 +447,170 @@ fn test_git_with_config_format_branch_only() {
     assert_eq!(vars.get("git"), Some(&"main".to_string()));
 }
 
+// =============================================================================
+// P3 (issue #38): coverage for previously-untested VariableBuilder methods.
+// Pure string-map builders: deterministic, no DB/env, so NO #[serial] needed.
+// =============================================================================
+
+#[test]
+fn test_variable_builder_set_inserts_and_skips_empty() {
+    let vars = VariableBuilder::new()
+        .set("k", "v".to_string())
+        .set("k2", String::new()) // empty -> must be suppressed (variables.rs:41)
+        .build();
+
+    assert_eq!(
+        vars.get("k"),
+        Some(&"v".to_string()),
+        "non-empty value should be inserted"
+    );
+    assert!(
+        !vars.contains_key("k2"),
+        "empty value must NOT create a key (empty suppression)"
+    );
+}
+
+#[test]
+fn test_variable_builder_duration() {
+    let color = "\x1b[36m";
+    let reset = "\x1b[0m";
+
+    // Non-empty: wrapped with color/reset.
+    let vars = VariableBuilder::new()
+        .duration("2h 15m", color, reset)
+        .build();
+    assert_eq!(
+        vars.get("duration"),
+        Some(&format!("{}{}{}", color, "2h 15m", reset)),
+        "duration should be wrapped with color and reset"
+    );
+
+    // Empty formatted -> no "duration" key (variables.rs:376 guard).
+    let empty = VariableBuilder::new().duration("", color, reset).build();
+    assert!(
+        !empty.contains_key("duration"),
+        "empty duration must NOT create a key"
+    );
+}
+
+#[test]
+fn test_variable_builder_token_rate_positive_and_zero() {
+    let color = "\x1b[90m";
+    let reset = "\x1b[0m";
+
+    // Positive rate -> "{:.1} tok/s".
+    let vars = VariableBuilder::new()
+        .token_rate(12.34, color, reset)
+        .build();
+    let token_rate = vars
+        .get("token_rate")
+        .expect("positive rate should set token_rate");
+    assert!(
+        token_rate.contains("12.3 tok/s"),
+        "token_rate should format rate to 1 decimal with tok/s; got {}",
+        token_rate
+    );
+
+    // rate == 0.0 -> no key (variables.rs:550 guard).
+    let zero = VariableBuilder::new().token_rate(0.0, color, reset).build();
+    assert!(
+        !zero.contains_key("token_rate"),
+        "rate of 0.0 must NOT create a token_rate key"
+    );
+}
+
+#[test]
+fn test_git_with_config_format_status() {
+    // Covers the format == "status" branch (variables.rs:181-187), distinct from the
+    // existing branch/show_when tests.
+    let config = GitComponentConfig {
+        format: "status".to_string(),
+        show_when: "always".to_string(),
+        color: String::new(),
+    };
+    let vars = VariableBuilder::new()
+        .git_with_config(
+            "main +2",
+            Some("main"),
+            Some("+2"),
+            true,
+            "",
+            "",
+            &config,
+        )
+        .build();
+
+    // status format inserts the raw status_only string into "git".
+    assert_eq!(
+        vars.get("git"),
+        Some(&"+2".to_string()),
+        "status format should insert the raw status_only string"
+    );
+    // git_branch is always set when a branch is present.
+    assert_eq!(
+        vars.get("git_branch"),
+        Some(&"main".to_string()),
+        "git_branch should always be set when a branch is present"
+    );
+}
+
+#[test]
+fn test_token_rate_with_config_time_units() {
+    // Covers the "minute" and "hour" time_unit branches (variables.rs:584-588), which
+    // the existing test_token_rate_with_config_sets_all_variables (second) does not assert.
+    let rate = 10.0; // tok/s
+
+    let minute_cfg = crate::config::TokenRateComponentConfig {
+        format: "rate_only".to_string(),
+        time_unit: "minute".to_string(),
+        show_session_total: false,
+        show_daily_total: false,
+        color: String::new(),
+    };
+    let minute_vars = VariableBuilder::new()
+        .token_rate_with_config(rate, None, None, "", "", &minute_cfg)
+        .build();
+    let minute = minute_vars
+        .get("token_rate_only")
+        .expect("minute unit should set token_rate_only");
+    assert!(
+        minute.contains("tok/min"),
+        "minute unit should use tok/min; got {}",
+        minute
+    );
+    // 10 tok/s * 60 = 600 tok/min.
+    assert!(
+        minute.contains("600"),
+        "minute rate should reflect rate*60 (600); got {}",
+        minute
+    );
+
+    let hour_cfg = crate::config::TokenRateComponentConfig {
+        format: "rate_only".to_string(),
+        time_unit: "hour".to_string(),
+        show_session_total: false,
+        show_daily_total: false,
+        color: String::new(),
+    };
+    let hour_vars = VariableBuilder::new()
+        .token_rate_with_config(rate, None, None, "", "", &hour_cfg)
+        .build();
+    let hour = hour_vars
+        .get("token_rate_only")
+        .expect("hour unit should set token_rate_only");
+    assert!(
+        hour.contains("tok/hr"),
+        "hour unit should use tok/hr; got {}",
+        hour
+    );
+    // 10 tok/s * 3600 = 36000 tok/hr -> formatted token count contains "36".
+    assert!(
+        hour.contains("36"),
+        "hour rate should reflect rate*3600 (36000); got {}",
+        hour
+    );
+}
+
 #[test]
 fn test_model_with_config_format_full() {
     let config = ModelComponentConfig {

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -927,3 +927,145 @@ fn test_burn_rate_config_min_duration_serde_default() {
         "Explicit min_duration_seconds should be respected"
     );
 }
+
+/// P1 (issue #38, BREAK-03 / D-04): pin the PRODUCTION write path.
+///
+/// `update_stats_data()` (persistence.rs:241) is the real entry point used on every
+/// hook invocation. When no `stats.db` exists yet it does
+/// `StatsData::load_from_sqlite().unwrap_or_else(|_| StatsData::load())` — and the
+/// `load()` fallback reads a legacy v2.x `stats.json` and migrates it into SQLite via
+/// `migrate_to_sqlite -> import_sessions`. Using `default()` instead would silently
+/// wipe a v2.x user's history on first v3.x run; this test guarantees it does not.
+///
+/// Unlike the existing `test_json_fallback_imports_when_sqlite_missing` (which calls
+/// `load()` directly and only checks `db_path.exists()`), this test:
+///   (1) exercises the real `update_stats_data()` entry point, and
+///   (2) asserts the migrated SESSION ROWS are PRESENT and CORRECT inside SQLite
+///       (via `db.get_all_sessions()`), proving data survived rather than just that a
+///       db file appeared.
+///
+/// Daily/monthly note: `import_sessions` (database/session.rs:679) imports ONLY the
+/// `sessions` map — it does NOT copy the JSON `daily`/`monthly` maps. This test asserts
+/// what the code ACTUALLY does (session-level survival) and records the daily/monthly
+/// finding in the issue SUMMARY rather than asserting an aspirational behavior.
+#[test]
+#[serial]
+fn test_update_stats_data_migrates_legacy_json_when_db_missing() {
+    use crate::database::SqliteDatabase;
+
+    let temp_dir = TempDir::new().unwrap();
+    env::set_var("XDG_DATA_HOME", temp_dir.path());
+    env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+    crate::config::reset_config();
+
+    let data_dir = get_data_dir();
+    fs::create_dir_all(&data_dir).unwrap();
+    let json_path = data_dir.join("stats.json");
+    let db_path = data_dir.join("stats.db");
+
+    // Precondition: a legacy stats.json exists, but NO stats.db. This is the exact
+    // state of a v2.x install on its first v3.x run, where the fallback must fire.
+    assert!(
+        !db_path.exists(),
+        "Precondition: stats.db must NOT exist (legacy-only state)"
+    );
+
+    // KNOWN legacy data: two sessions with distinct cost/lines, plus populated
+    // daily/monthly/all_time blocks (to verify they are NOT lost AND to observe what
+    // import_sessions migrates).
+    let json = r#"{
+        "version": "1.0",
+        "created": "2025-01-01T00:00:00Z",
+        "last_updated": "2025-01-02T12:00:00Z",
+        "sessions": {
+            "legacy-session-a": {
+                "last_updated": "2025-01-01T10:00:00Z",
+                "cost": 12.50,
+                "lines_added": 100,
+                "lines_removed": 40,
+                "start_time": "2025-01-01T09:00:00Z"
+            },
+            "legacy-session-b": {
+                "last_updated": "2025-01-02T11:00:00Z",
+                "cost": 7.25,
+                "lines_added": 33,
+                "lines_removed": 11,
+                "start_time": "2025-01-02T10:00:00Z"
+            }
+        },
+        "daily": {
+            "2025-01-01": {"total_cost": 12.50, "sessions": ["legacy-session-a"], "lines_added": 100, "lines_removed": 40},
+            "2025-01-02": {"total_cost": 7.25, "sessions": ["legacy-session-b"], "lines_added": 33, "lines_removed": 11}
+        },
+        "monthly": {
+            "2025-01": {"total_cost": 19.75, "sessions": 2, "lines_added": 133, "lines_removed": 51}
+        },
+        "all_time": {"total_cost": 19.75, "sessions": 2, "since": "2025-01-01T00:00:00Z"}
+    }"#;
+    fs::write(&json_path, json).unwrap();
+
+    // Exercise the PRODUCTION entry point with a no-op updater. The point is to prove
+    // the LOAD/fallback inside update_stats_data migrated the legacy data — not to add
+    // new sessions. (Closure satisfies FnOnce(&mut StatsData) -> (f64, f64).)
+    let _ = update_stats_data(|_stats: &mut StatsData| (0.0, 0.0));
+
+    // (1) Migration created the SQLite database.
+    assert!(
+        db_path.exists(),
+        "update_stats_data() should have created the SQLite database via fallback migration"
+    );
+
+    // (2) Both legacy sessions are PRESENT and CORRECT in SQLite (data migrated, not wiped).
+    let db = SqliteDatabase::new(&db_path).unwrap();
+    let sessions = db.get_all_sessions().unwrap();
+
+    assert_eq!(
+        sessions.len(),
+        2,
+        "v2.x history must survive: expected 2 migrated sessions, got {}",
+        sessions.len()
+    );
+
+    let a = sessions
+        .get("legacy-session-a")
+        .expect("legacy-session-a must be migrated, not wiped");
+    assert_eq!(a.cost, 12.50, "session-a cost must survive migration");
+    assert_eq!(a.lines_added, 100, "session-a lines_added must survive");
+    assert_eq!(a.lines_removed, 40, "session-a lines_removed must survive");
+
+    let b = sessions
+        .get("legacy-session-b")
+        .expect("legacy-session-b must be migrated, not wiped");
+    assert_eq!(b.cost, 7.25, "session-b cost must survive migration");
+    assert_eq!(b.lines_added, 33, "session-b lines_added must survive");
+    assert_eq!(b.lines_removed, 11, "session-b lines_removed must survive");
+
+    // (3) The result is NOT an empty default — history preserved.
+    assert!(
+        !sessions.is_empty(),
+        "fallback must not return an empty default (that is the BREAK-03 bug)"
+    );
+
+    // FINDING (recorded in SUMMARY): import_sessions migrates ONLY the sessions map.
+    // The JSON daily/monthly maps are NOT copied into daily_stats/monthly_stats by the
+    // migration path. Assert the ACTUAL behavior: no daily/monthly rows are produced
+    // purely by importing sessions (a no-op update does not write the current day either,
+    // since the updater added no cost). Session-level survival is the data-integrity
+    // guarantee this test pins.
+    let daily = db.get_all_daily_stats().unwrap();
+    let monthly = db.get_all_monthly_stats().unwrap();
+    assert!(
+        !daily.contains_key("2025-01-01") && !daily.contains_key("2025-01-02"),
+        "DOCUMENTED: import_sessions does not migrate the JSON daily map (got: {:?})",
+        daily.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !monthly.contains_key("2025-01"),
+        "DOCUMENTED: import_sessions does not migrate the JSON monthly map (got: {:?})",
+        monthly.keys().collect::<Vec<_>>()
+    );
+
+    env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
+}

--- a/tests/context_learning_sanitization_tests.rs
+++ b/tests/context_learning_sanitization_tests.rs
@@ -9,31 +9,8 @@
 mod test_support;
 
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
-
-// Helper function to get the statusline binary path
-fn get_binary_path() -> PathBuf {
-    // Try release first, then debug
-    let release_path = PathBuf::from("./target/release/statusline");
-    if release_path.exists() {
-        return release_path;
-    }
-
-    let debug_path = PathBuf::from("./target/debug/statusline");
-    if debug_path.exists() {
-        return debug_path;
-    }
-
-    // If neither exists, try to build release
-    Command::new("cargo")
-        .args(["build", "--release", "--quiet"])
-        .output()
-        .expect("Failed to build release binary");
-
-    release_path
-}
 
 fn setup_test_database_with_malicious_data() -> TempDir {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -120,7 +97,7 @@ fn test_context_learning_status_sanitizes_model_name() {
     let _guard = test_support::init();
     let temp_dir = setup_test_database_with_malicious_data();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("context-learning")
@@ -159,7 +136,7 @@ fn test_context_learning_details_sanitizes_workspace() {
     let _guard = test_support::init();
     let temp_dir = setup_test_database_with_malicious_data();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("context-learning")
@@ -185,7 +162,7 @@ fn test_context_learning_details_sanitizes_device_id() {
     let _guard = test_support::init();
     let temp_dir = setup_test_database_with_malicious_data();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("context-learning")
@@ -213,7 +190,7 @@ fn test_context_learning_handles_missing_model() {
     let temp_dir = setup_test_database_with_malicious_data();
 
     // Try to get details for a model that doesn't exist
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("context-learning")

--- a/tests/context_tokens_display_tests.rs
+++ b/tests/context_tokens_display_tests.rs
@@ -12,21 +12,6 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
-/// Get the path to the test-built binary
-fn get_test_binary() -> String {
-    std::env::var("CARGO_BIN_EXE_statusline")
-        .or_else(|_| -> Result<String, std::env::VarError> {
-            if std::path::Path::new("./target/debug/statusline").exists() {
-                Ok("./target/debug/statusline".to_string())
-            } else if std::path::Path::new("./target/release/statusline").exists() {
-                Ok("./target/release/statusline".to_string())
-            } else {
-                Ok("./target/debug/statusline".to_string())
-            }
-        })
-        .unwrap()
-}
-
 /// Create a config file with show_context_tokens setting
 fn create_config(show_context_tokens: bool) -> std::path::PathBuf {
     let path = std::env::temp_dir().join(format!(
@@ -89,7 +74,7 @@ fn test_context_tokens_shown_when_enabled() {
         transcript.to_str().unwrap()
     );
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .env("STATUSLINE_CONFIG", &config_file)
@@ -145,7 +130,7 @@ fn test_context_tokens_hidden_when_disabled() {
         transcript.to_str().unwrap()
     );
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .env("STATUSLINE_CONFIG", &config_file)
@@ -216,7 +201,7 @@ fn test_context_tokens_formatting() {
             transcript.to_str().unwrap()
         );
 
-        let cmd_output = Command::new(get_test_binary())
+        let cmd_output = Command::new(test_support::test_binary())
             .env("XDG_DATA_HOME", temp_dir.path())
             .env("XDG_CONFIG_HOME", temp_dir.path())
             .env("STATUSLINE_CONFIG", &config_file)
@@ -265,7 +250,7 @@ fn test_context_tokens_without_transcript() {
     // JSON without transcript - context bar should not appear
     let json = r#"{"workspace":{"current_dir":"/tmp"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .env("STATUSLINE_CONFIG", &config_file)

--- a/tests/db_maintenance_tests.rs
+++ b/tests/db_maintenance_tests.rs
@@ -10,28 +10,6 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
-// Helper function to get the statusline binary path
-fn get_binary_path() -> PathBuf {
-    // Try release first, then debug
-    let release_path = PathBuf::from("./target/release/statusline");
-    if release_path.exists() {
-        return release_path;
-    }
-
-    let debug_path = PathBuf::from("./target/debug/statusline");
-    if debug_path.exists() {
-        return debug_path;
-    }
-
-    // If neither exists, try to build release
-    Command::new("cargo")
-        .args(["build", "--release", "--quiet"])
-        .output()
-        .expect("Failed to build release binary");
-
-    release_path
-}
-
 fn setup_test_database() -> (TempDir, PathBuf) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -43,7 +21,7 @@ fn setup_test_database() -> (TempDir, PathBuf) {
 
     // Initialize the database by running statusline with minimal input
     // Use a session_id and higher cost to ensure database creation
-    let mut child = Command::new(get_binary_path())
+    let mut child = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .stdin(std::process::Stdio::piped())
@@ -141,7 +119,7 @@ fn setup_test_database() -> (TempDir, PathBuf) {
 #[test]
 fn test_db_maintain_command_exists() {
     let _guard = test_support::init();
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .arg("db-maintain")
         .arg("--help")
         .output()
@@ -160,7 +138,7 @@ fn test_db_maintain_basic_execution() {
     let _guard = test_support::init();
     let (temp_dir, _db_path) = setup_test_database();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")
@@ -176,7 +154,7 @@ fn test_db_maintain_verbose_output() {
     let _guard = test_support::init();
     let (temp_dir, _db_path) = setup_test_database();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")
@@ -202,7 +180,7 @@ fn test_db_maintain_force_vacuum() {
     let _guard = test_support::init();
     let (temp_dir, _db_path) = setup_test_database();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")
@@ -219,7 +197,7 @@ fn test_db_maintain_no_prune() {
     let _guard = test_support::init();
     let (temp_dir, _db_path) = setup_test_database();
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")
@@ -238,7 +216,7 @@ fn test_db_maintain_missing_database() {
     // Create a temp dir but don't create a database
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")
@@ -333,7 +311,7 @@ fn test_db_maintain_pruning() {
     }
 
     // Run maintenance with pruning
-    let output = Command::new(get_binary_path())
+    let output = Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("db-maintain")

--- a/tests/hook_integration_tests.rs
+++ b/tests/hook_integration_tests.rs
@@ -3,29 +3,14 @@
 //! Tests the complete workflow of PreCompact/Stop hooks interacting with
 //! the statusline display to provide real-time compaction feedback.
 
+#[path = "test_support.rs"]
+mod test_support;
+
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-
-/// Get the path to the compiled statusline binary
-fn get_test_binary() -> PathBuf {
-    // Try release first, then debug
-    let release_path = PathBuf::from(env!("CARGO_BIN_EXE_statusline"));
-    if release_path.exists() {
-        return release_path;
-    }
-
-    // Fallback to debug build
-    let mut debug_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    debug_path.push("target/debug/statusline");
-    if debug_path.exists() {
-        return debug_path;
-    }
-
-    panic!("Could not find statusline binary");
-}
 
 /// Create a test transcript with token counts
 fn create_test_transcript(dir: &TempDir) -> PathBuf {
@@ -49,7 +34,7 @@ fn create_test_input(session_id: &str, transcript: &Path) -> String {
 #[test]
 fn test_hook_precompact_creates_state_file() {
     let session_id = format!("test-precompact-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Run precompact hook
     let output = Command::new(&binary)
@@ -83,7 +68,7 @@ fn test_hook_precompact_creates_state_file() {
 #[test]
 fn test_hook_stop_clears_state_file() {
     let session_id = format!("test-stop-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Create state first
     Command::new(&binary)
@@ -118,7 +103,7 @@ fn test_hook_stop_clears_state_file() {
 #[test]
 fn test_statusline_detects_hook_compaction() {
     let session_id = format!("test-detect-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
     let temp_dir = TempDir::new().unwrap();
     let transcript = create_test_transcript(&temp_dir);
     let input = create_test_input(&session_id, &transcript);
@@ -171,7 +156,7 @@ fn test_statusline_detects_hook_compaction() {
 #[test]
 fn test_statusline_without_hook_shows_percentage() {
     let session_id = format!("test-nohook-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
     let temp_dir = TempDir::new().unwrap();
     let transcript = create_test_transcript(&temp_dir);
     let input = create_test_input(&session_id, &transcript);
@@ -214,7 +199,7 @@ fn test_statusline_without_hook_shows_percentage() {
 #[test]
 fn test_hook_state_transition() {
     let session_id = format!("test-transition-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
     let temp_dir = TempDir::new().unwrap();
     let transcript = create_test_transcript(&temp_dir);
     let input = create_test_input(&session_id, &transcript);
@@ -281,7 +266,7 @@ fn test_hook_state_transition() {
 fn test_multiple_sessions_isolated() {
     let session_a = format!("test-multi-a-{}", std::process::id());
     let session_b = format!("test-multi-b-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Set hook for session A only
     Command::new(&binary)
@@ -310,7 +295,7 @@ fn test_multiple_sessions_isolated() {
 #[test]
 fn test_hook_trigger_types() {
     let session_id = format!("test-triggers-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
     let cache_dir = dirs::cache_dir().unwrap().join("claudia-statusline");
     let state_file = cache_dir.join(format!("state-{}.json", session_id));
 
@@ -349,7 +334,7 @@ fn test_hook_trigger_types() {
 #[test]
 fn test_hook_idempotency() {
     let session_id = format!("test-idempotent-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Call precompact multiple times
     for _ in 0..3 {
@@ -386,7 +371,7 @@ fn test_hook_idempotency() {
 #[test]
 fn test_hook_postcompact_clears_state_file() {
     let session_id = format!("test-postcompact-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Create state first (simulates PreCompact)
     Command::new(&binary)
@@ -428,7 +413,7 @@ fn test_hook_postcompact_clears_state_file() {
 #[test]
 fn test_hook_postcompact_without_precompact() {
     let session_id = format!("test-postcompact-nopre-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // PostCompact without PreCompact should not error (idempotent)
     let output = Command::new(&binary)
@@ -449,7 +434,7 @@ fn test_hook_postcompact_without_precompact() {
 #[test]
 fn test_full_compaction_lifecycle_with_postcompact() {
     let session_id = format!("test-lifecycle-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
     let temp_dir = TempDir::new().unwrap();
     let transcript = create_test_transcript(&temp_dir);
     let input = create_test_input(&session_id, &transcript);
@@ -526,7 +511,7 @@ fn test_full_compaction_lifecycle_with_postcompact() {
 #[test]
 fn test_postcompact_idempotency() {
     let session_id = format!("test-postcompact-idemp-{}", std::process::id());
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // Create state
     Command::new(&binary)
@@ -565,7 +550,7 @@ fn test_postcompact_with_empty_session_id() {
     //
     // Note: Claude Code sends empty session_id via stdin JSON, not CLI args.
     // The CLI validates non-empty session_id, but stdin JSON bypasses this.
-    let binary = get_test_binary();
+    let binary = test_support::test_binary();
 
     // First, create a state file with a real session_id (PreCompact works normally)
     let real_session_id = format!("test-empty-workaround-{}", std::process::id());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,31 +8,12 @@ mod test_support;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-/// Get the path to the test-built binary
-fn get_test_binary() -> String {
-    // Use CARGO_BIN_EXE_statusline environment variable set by cargo test
-    // This points to the binary built for testing
-    std::env::var("CARGO_BIN_EXE_statusline")
-        .or_else(|_| -> Result<String, std::env::VarError> {
-            // Try to find the binary in common locations
-            if std::path::Path::new("./target/debug/statusline").exists() {
-                Ok("./target/debug/statusline".to_string())
-            } else if std::path::Path::new("./target/release/statusline").exists() {
-                Ok("./target/release/statusline".to_string())
-            } else {
-                // Fallback to debug location
-                Ok("./target/debug/statusline".to_string())
-            }
-        })
-        .unwrap()
-}
-
 #[test]
 fn test_binary_with_empty_input() {
     // Initialize test environment isolation - child process inherits env vars
     let _guard = test_support::init();
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -63,7 +44,7 @@ fn test_binary_with_workspace() {
     let _guard = test_support::init();
     let json = r#"{"workspace":{"current_dir":"/tmp"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -84,7 +65,7 @@ fn test_binary_with_model() {
     let _guard = test_support::init();
     let json = r#"{"model":{"display_name":"Claude Opus"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -105,7 +86,7 @@ fn test_binary_with_cost() {
     let _guard = test_support::init();
     let json = r#"{"cost":{"total_cost_usd":5.50}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -135,7 +116,7 @@ fn test_binary_with_complete_input() {
         }
     }"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -158,7 +139,7 @@ fn test_binary_handles_malformed_json() {
     let _guard = test_support::init();
     let json = r#"{"workspace":{"current_dir":"/tmp"#; // Missing closing braces
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -178,7 +159,7 @@ fn test_binary_with_unicode() {
     let _guard = test_support::init();
     let json = r#"{"workspace":{"current_dir":"/home/用户/文档"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -199,7 +180,7 @@ fn test_binary_with_null_values() {
     let _guard = test_support::init();
     let json = r#"{"workspace":{"current_dir":null},"model":{"display_name":null}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -219,7 +200,7 @@ fn test_binary_output_contains_ansi_colors() {
     let _guard = test_support::init();
     let json = r#"{"workspace":{"current_dir":"/tmp"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env_remove("NO_COLOR") // Ensure colors are enabled for this test
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -240,7 +221,7 @@ fn test_binary_output_contains_ansi_colors() {
 #[test]
 fn test_version_flag() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--version")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -264,7 +245,7 @@ fn test_version_flag() {
 #[test]
 fn test_version_full_flag() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--version-full")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -282,7 +263,7 @@ fn test_version_full_flag() {
 #[test]
 fn test_version_flag_short() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("-V")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -298,7 +279,7 @@ fn test_version_flag_short() {
 #[test]
 fn test_help_flag() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--help")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -316,7 +297,7 @@ fn test_help_flag() {
 #[test]
 fn test_help_flag_short() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("-h")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -335,7 +316,7 @@ fn test_binary_with_home_directory() {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
     let json = format!(r#"{{"workspace":{{"current_dir":"{}"}}}}"#, home);
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -359,7 +340,7 @@ fn test_session_id_with_empty_cost() {
     // Test that day charge still shows when session_id exists but cost is empty
     let json = r#"{"workspace":{"current_dir":"/test"},"session_id":"test-123","cost":{}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -382,7 +363,7 @@ fn test_transcript_field_parsing() {
     // Test that 'transcript' field is properly parsed
     let json = r#"{"workspace":{"current_dir":"/test"},"transcript":"/tmp/test.jsonl"}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -404,7 +385,7 @@ fn test_session_id_without_cost() {
     // Test with session_id but no cost object at all
     let json = r#"{"workspace":{"current_dir":"/test"},"session_id":"test-456"}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -445,7 +426,7 @@ fn test_concurrent_stats_updates() {
                 i
             );
 
-            let output = Command::new(get_test_binary())
+            let output = Command::new(test_support::test_binary())
                 .env("XDG_DATA_HOME", temp_path_clone)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
@@ -484,7 +465,7 @@ fn test_no_color_environment_variable() {
     // Test that NO_COLOR=1 disables ANSI escape codes
     let json = r#"{"workspace":{"current_dir":"/tmp"},"model":{"display_name":"Claude Opus"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -517,7 +498,7 @@ fn test_colors_enabled_by_default() {
     // Test that colors are enabled by default
     let json = r#"{"workspace":{"current_dir":"/tmp"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env_remove("NO_COLOR") // Ensure colors are enabled for this test
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -543,7 +524,7 @@ fn test_colors_enabled_by_default() {
 #[test]
 fn test_health_command() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("health")
         .output()
         .expect("Failed to execute binary");
@@ -564,7 +545,7 @@ fn test_health_command() {
 #[test]
 fn test_health_command_json() {
     let _guard = test_support::init();
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .args(["health", "--json"])
         .output()
         .expect("Failed to execute binary");
@@ -591,7 +572,7 @@ fn test_no_color_flag() {
     let _guard = test_support::init();
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--no-color")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -622,7 +603,7 @@ fn test_cli_precedence() {
     // Test that CLI flags override environment variables
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--no-color")
         .env("NO_COLOR", "0") // Environment says enable colors
         .stdin(std::process::Stdio::piped())
@@ -654,7 +635,7 @@ fn test_log_level_precedence() {
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
     // Test 1: CLI flag overrides env var
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .args(["--log-level", "debug"])
         .env("RUST_LOG", "error") // Environment says error only
         .stdin(std::process::Stdio::piped())
@@ -679,7 +660,7 @@ fn test_theme_precedence() {
     // Test that --theme flag overrides STATUSLINE_THEME and CLAUDE_THEME env vars
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .args(["--theme", "dark"])
         .env_remove("NO_COLOR") // Ensure colors are enabled for this test
         .env("STATUSLINE_THEME", "light") // Environment says light
@@ -733,7 +714,7 @@ window_size = 100000
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
     // Test that --config flag is used
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .args(["--config", config_path.to_str().unwrap()])
         .env("STATUSLINE_CONFIG", "/nonexistent/config.toml") // Env points to nonexistent file
         .stdin(std::process::Stdio::piped())
@@ -759,7 +740,7 @@ fn test_multiple_cli_flags_precedence() {
     // Test that multiple CLI flags work together and all override env vars
     let input = r#"{"workspace":{"current_dir":"/test"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .args(["--no-color", "--theme", "light", "--log-level", "warn"])
         .env("NO_COLOR", "0") // Env says colors enabled
         .env("STATUSLINE_THEME", "dark") // Env says dark theme
@@ -792,7 +773,7 @@ fn test_test_mode_flag() {
     // Test that --test-mode flag shows TEST indicator
     let json = r#"{"workspace":{"current_dir":"/tmp"},"model":{"display_name":"Claude Sonnet"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--test-mode")
         .env_remove("NO_COLOR") // Ensure colors are enabled for this test
         .stdin(Stdio::piped())
@@ -850,7 +831,7 @@ fn test_test_mode_uses_isolated_database() {
     // Run statusline with test mode, using temp HOME for complete isolation
     let json = r#"{"session_id":"test-isolation-check","workspace":{"current_dir":"/tmp"},"cost":{"total_cost_usd":0.01}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .arg("--test-mode")
         .env("HOME", temp_home_path) // Use temp HOME, not real HOME
         .stdin(Stdio::piped())
@@ -873,7 +854,7 @@ fn test_test_mode_uses_isolated_database() {
     );
 
     // Run again to ensure we're not touching prod database
-    let output2 = Command::new(get_test_binary())
+    let output2 = Command::new(test_support::test_binary())
         .arg("--test-mode")
         .env("HOME", temp_home_path) // Use temp HOME, not real HOME
         .stdin(Stdio::piped())
@@ -906,7 +887,7 @@ fn test_test_mode_without_flag() {
     // Test that without --test-mode flag, no TEST indicator appears
     let json = r#"{"workspace":{"current_dir":"/tmp"}}"#;
 
-    let output = Command::new(get_test_binary())
+    let output = Command::new(test_support::test_binary())
         .env_remove("STATUSLINE_TEST_MODE") // Ensure test mode is not set
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/tests/json_backup_legacy_warning.rs
+++ b/tests/json_backup_legacy_warning.rs
@@ -14,24 +14,11 @@
 //! helper (the same pattern as `tests/sqlite_integration_tests.rs`). This test does
 //! NOT depend on `assert_cmd` (it is not a dev-dependency of this project).
 
+#[path = "test_support.rs"]
+mod test_support;
+
 use std::io::Write;
 use tempfile::TempDir;
-
-/// Get the path to the test binary, with fallback paths for different build scenarios.
-/// Mirrors the helper in `tests/sqlite_integration_tests.rs`.
-fn get_test_binary() -> String {
-    std::env::var("CARGO_BIN_EXE_statusline")
-        .or_else(|_| -> Result<String, std::env::VarError> {
-            if std::path::Path::new("./target/debug/statusline").exists() {
-                Ok("./target/debug/statusline".to_string())
-            } else if std::path::Path::new("./target/release/statusline").exists() {
-                Ok("./target/release/statusline".to_string())
-            } else {
-                Ok("./target/debug/statusline".to_string())
-            }
-        })
-        .unwrap()
-}
 
 /// Run the statusline binary with an isolated XDG_CONFIG_HOME/XDG_DATA_HOME containing
 /// the given config.toml body, feeding `{}` on stdin. Returns the captured output.
@@ -41,7 +28,7 @@ fn run_with_config(config_body: &str) -> std::process::Output {
     std::fs::create_dir_all(&config_app_dir).unwrap();
     std::fs::write(config_app_dir.join("config.toml"), config_body).unwrap();
 
-    let mut child = std::process::Command::new(get_test_binary())
+    let mut child = std::process::Command::new(test_support::test_binary())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .env("XDG_DATA_HOME", temp_dir.path())
         .stdin(std::process::Stdio::piped())

--- a/tests/sqlite_integration_tests.rs
+++ b/tests/sqlite_integration_tests.rs
@@ -11,24 +11,6 @@ use std::sync::Arc;
 use std::thread;
 use tempfile::TempDir;
 
-/// Get the path to the test binary, with fallback paths for different build scenarios
-fn get_test_binary() -> String {
-    // Check for the environment variable that Cargo sets when running tests
-    std::env::var("CARGO_BIN_EXE_statusline")
-        .or_else(|_| -> Result<String, std::env::VarError> {
-            // Fallback: check common locations
-            if std::path::Path::new("./target/debug/statusline").exists() {
-                Ok("./target/debug/statusline".to_string())
-            } else if std::path::Path::new("./target/release/statusline").exists() {
-                Ok("./target/release/statusline".to_string())
-            } else {
-                // Default to debug path if nothing exists yet
-                Ok("./target/debug/statusline".to_string())
-            }
-        })
-        .unwrap()
-}
-
 // v3.0.0 (Plan 06-01): converted from the former `test_dual_write_creates_both_files`.
 // After JSON write removal, the binary writes ONLY to SQLite. This regression asserts
 // that stats.db is created and stats.json is NOT.
@@ -59,7 +41,7 @@ fn test_sqlite_write_no_json_file() {
     }"#;
 
     // Run statusline with the input
-    let mut child = std::process::Command::new(get_test_binary())
+    let mut child = std::process::Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .stdin(std::process::Stdio::piped())
@@ -135,7 +117,7 @@ fn test_legacy_json_migrates_to_sqlite() {
         "session_id": "fresh-session",
         "cost": {"total_cost_usd": 5.0}
     }"#;
-    let mut child = std::process::Command::new(get_test_binary())
+    let mut child = std::process::Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .stdin(std::process::Stdio::piped())
@@ -605,7 +587,7 @@ fn test_cost_reduction_updates_correctly() {
         "cost": {"total_cost_usd": 10.0, "total_lines_added": 200, "total_lines_removed": 50}
     }"#;
 
-    let mut output1 = std::process::Command::new(get_test_binary())
+    let mut output1 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -631,7 +613,7 @@ fn test_cost_reduction_updates_correctly() {
         "cost": {"total_cost_usd": 6.0, "total_lines_added": 210, "total_lines_removed": 55}
     }"#;
 
-    let mut output2 = std::process::Command::new(get_test_binary())
+    let mut output2 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -670,7 +652,7 @@ fn test_unchanged_cost_updates_metadata() {
         "cost": {"total_cost_usd": 5.0, "total_lines_added": 100, "total_lines_removed": 20}
     }"#;
 
-    let mut cmd1 = std::process::Command::new(get_test_binary())
+    let mut cmd1 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -692,7 +674,7 @@ fn test_unchanged_cost_updates_metadata() {
         "cost": {"total_cost_usd": 5.0, "total_lines_added": 150, "total_lines_removed": 30}
     }"#;
 
-    let mut cmd2 = std::process::Command::new(get_test_binary())
+    let mut cmd2 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -734,7 +716,7 @@ fn test_multiple_sessions_increment_count() {
             i, i
         );
 
-        let mut cmd = std::process::Command::new(get_test_binary())
+        let mut cmd = std::process::Command::new(test_support::test_binary())
             .env("NO_COLOR", "1")
             .env("XDG_DATA_HOME", temp_dir.path())
             .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -751,7 +733,7 @@ fn test_multiple_sessions_increment_count() {
     }
 
     // Check health output to verify session count
-    let health_output = std::process::Command::new(get_test_binary())
+    let health_output = std::process::Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("health")
@@ -783,7 +765,7 @@ fn test_line_counts_use_deltas() {
         "cost": {"total_cost_usd": 5.0, "total_lines_added": 200, "total_lines_removed": 50}
     }"#;
 
-    let mut cmd1 = std::process::Command::new(get_test_binary())
+    let mut cmd1 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -807,7 +789,7 @@ fn test_line_counts_use_deltas() {
         "cost": {"total_cost_usd": 6.0, "total_lines_added": 210, "total_lines_removed": 55}
     }"#;
 
-    let mut cmd2 = std::process::Command::new(get_test_binary())
+    let mut cmd2 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -844,7 +826,7 @@ fn test_multi_day_session_counts_correctly() {
         "cost": {"total_cost_usd": 10.0, "total_lines_added": 100, "total_lines_removed": 20}
     }"#;
 
-    let mut cmd1 = std::process::Command::new(get_test_binary())
+    let mut cmd1 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -867,7 +849,7 @@ fn test_multi_day_session_counts_correctly() {
         "cost": {"total_cost_usd": 15.0, "total_lines_added": 150, "total_lines_removed": 30}
     }"#;
 
-    let mut cmd2 = std::process::Command::new(get_test_binary())
+    let mut cmd2 = std::process::Command::new(test_support::test_binary())
         .env("NO_COLOR", "1")
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -884,7 +866,7 @@ fn test_multi_day_session_counts_correctly() {
 
     // Check health to verify session count
     // The session should be counted once globally but may appear in multiple days
-    let health_output = std::process::Command::new(get_test_binary())
+    let health_output = std::process::Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("health")
@@ -924,7 +906,7 @@ fn test_monthly_sessions_no_overcount() {
             day * 5
         );
 
-        let mut cmd = std::process::Command::new(get_test_binary())
+        let mut cmd = std::process::Command::new(test_support::test_binary())
             .env("NO_COLOR", "1")
             .env("XDG_DATA_HOME", temp_dir.path())
             .env("XDG_CONFIG_HOME", temp_dir.path())
@@ -941,7 +923,7 @@ fn test_monthly_sessions_no_overcount() {
     }
 
     // Health check should show 1 session total (not 3)
-    let health_output = std::process::Command::new(get_test_binary())
+    let health_output = std::process::Command::new(test_support::test_binary())
         .env("XDG_DATA_HOME", temp_dir.path())
         .env("XDG_CONFIG_HOME", temp_dir.path())
         .arg("health")

--- a/tests/test_support.rs
+++ b/tests/test_support.rs
@@ -40,6 +40,7 @@ static TEMP_BASE: OnceLock<TempDir> = OnceLock::new();
 
 /// Guard that ensures the temp directory stays alive.
 /// The directory is cleaned up when the test process exits.
+#[allow(dead_code)]
 pub struct TestEnvGuard {
     _private: (),
 }
@@ -63,6 +64,7 @@ pub struct TestEnvGuard {
 ///
 /// All variables starting with `STATUSLINE_` or `CLAUDE_` are cleared.
 /// Tests that need specific values should set them after calling `init()`.
+#[allow(dead_code)]
 pub fn init() -> TestEnvGuard {
     // Use OnceLock::get_or_init for thread-safe, single initialization
     TEMP_BASE.get_or_init(|| {
@@ -113,6 +115,18 @@ pub fn init() -> TestEnvGuard {
     });
 
     TestEnvGuard { _private: () }
+}
+
+/// Path to the compiled `statusline` binary under test.
+///
+/// Uses the compile-time `CARGO_BIN_EXE_statusline` macro, which Cargo GUARANTEES to
+/// set for integration tests and which points at the exact binary built for this test
+/// run. This replaces the previous per-file `get_test_binary()` helpers that did a
+/// runtime `env::var` lookup with a hardcoded `./target/debug/statusline` fallback —
+/// a fragile path that could silently point at a stale or missing binary.
+#[allow(dead_code)]
+pub fn test_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_statusline")
 }
 
 /// Get the base temp directory path (for tests that need to create files)


### PR DESCRIPTION
Closes #38. Adds unit-test coverage via GSD `/gsd:quick`; **test-only**, independently verified.

## What was added (10 new tests, 5 atomic commits)

- **P1 — legacy-JSON migration pin (data-integrity centerpiece).** A regression test exercising the real `update_stats_data()` entry point with an isolated temp XDG containing a legacy `stats.json` and no `stats.db`, asserting migrated sessions are **present and correct** (via `get_all_sessions()`) — i.e. v2.x history is migrated, not wiped. The existing test only checked `db_path.exists()` via `load()` directly.
- **P2 — `database/session.rs` active-time calculation.** Unit coverage of the `update_session_tx` active-time branch (gap added below threshold, skipped above, first-update zero) + a same-transaction daily-aggregate write. Uses SQL backdating, no sleeps.
- **P3 — `layout/variables.rs` `VariableBuilder`.** Covered the previously-untested builder methods (set/duration/token_rate/git-status/time-units). (The `{placeholder}` engine in template.rs was already well-tested.)
- **P4 — robust test-binary resolution.** Consolidated the duplicated `get_test_binary()`/`get_binary_path()` (with the fragile hardcoded `./target/debug` fallback) across 7 integration files into one `tests/test_support::test_binary()` using the compile-time `env!("CARGO_BIN_EXE_statusline")` macro.

## Finding worth a follow-up

P1 revealed that `import_sessions` migrates **only the `sessions` map** — a legacy `stats.json`'s `daily`/`monthly` aggregate totals are **not** back-filled into SQLite (they're produced normally by later updates, just not migrated). The test pins this actual behavior. **Suggest a follow-up issue:** either back-fill daily/monthly on legacy migration, or document the limitation in `MIGRATION_GUIDE.md`.

## Verification (independently re-run)

- `git diff main -- src/` touches only `{stats,database,layout}/tests.rs` — **no production code, no new `pub`/visibility**.
- P4: no hardcoded `target/debug` fallback remains; 8 files use the shared `env!`-based helper.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean.
- lib tests **5/5 runs green** (445 each); full suite **2/2 green** (1085 passed, 0 failed). Deterministic.

## Note

One test-only deviation: the new P2 tests mutate the process-global `STATUSLINE_BURN_RATE_MODE`, which exposed 3 pre-existing non-`#[serial]` active-time storage tests to a race — fixed by marking them `#[serial]` + pinning mode + `reset_config()` (the #34/#35 convention).