### PR TITLE
Pin Rust toolchain via rust-toolchain.toml (#51)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Install and run cargo-audit
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         components: rustfmt, clippy
 
@@ -50,7 +50,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -139,7 +139,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -225,7 +225,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Install cargo-deny
       run: cargo install cargo-deny --locked

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         targets: ${{ matrix.arch == 'amd64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
 
@@ -126,7 +126,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         targets: x86_64-pc-windows-msvc
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         components: rustfmt, clippy
 
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -189,7 +189,7 @@ jobs:
         sudo apt-get install -y jq curl patch make
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Test install script help
       run: ./scripts/install-statusline.sh --help
@@ -237,7 +237,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Install build dependencies
       run: |
@@ -333,7 +333,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Build project
       run: cargo build --release
@@ -436,7 +436,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Build project
       run: cargo build --release
@@ -522,7 +522,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
 
     - name: Cache cargo registry
       uses: actions/cache@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,21 @@ We follow a phase-based development approach with acceptance criteria for each f
 ## Development Setup
 
 ### Prerequisites
-- Rust 1.70+ (install via [rustup](https://rustup.rs/))
+- Rust (install via [rustup](https://rustup.rs/)) — the exact version is **pinned** in
+  `rust-toolchain.toml`, which rustup honours automatically (it installs the pinned
+  toolchain + `rustfmt`/`clippy` on your first `cargo` command). This keeps local
+  `cargo fmt`/`cargo clippy` byte-for-byte consistent with CI.
 - Git
 - Make (optional but recommended)
+
+#### Bumping the pinned toolchain
+The Rust version lives in two places that must stay in sync, bumped together in one PR
+so any resulting `rustfmt`/`clippy` changes land deliberately:
+1. `channel` in `rust-toolchain.toml`
+2. the `dtolnay/rust-toolchain@<version>` refs in `.github/workflows/*.yml`, e.g.:
+   ```bash
+   sed -i 's#rust-toolchain@1\.96\.0#rust-toolchain@<new>#g' .github/workflows/*.yml
+   ```
 
 ### Getting Started
 ```bash

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,14 @@
+# Pinned toolchain so local builds and CI agree on rustc/rustfmt/clippy.
+#
+# Single source of truth for the Rust version. rustup honours this file for every
+# `cargo` invocation (locally and in CI) and auto-installs the toolchain + components
+# on first use, so contributors don't hit spurious `cargo fmt`/`clippy` diffs from a
+# newer floating `stable` (the failure mode that bit issue #38 / motivated #51).
+#
+# To bump: change `channel` here AND the matching `dtolnay/rust-toolchain@<version>`
+# refs in .github/workflows/*.yml (see CONTRIBUTING.md), in one reviewed PR — so any
+# resulting rustfmt/clippy changes land deliberately, not as surprise CI breakage.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Closes #51. CI/dev-env hygiene; no code change.

## Problem
CI installed a floating `stable` (`dtolnay/rust-toolchain@stable`), so local and CI `rustfmt`/`clippy` drifted whenever a new stable landed. This bit #38: a `cargo fmt --check` that passed locally (1.95.0) failed in CI when stable moved to 1.96.0.

## Fix
- **`rust-toolchain.toml`** (new): pins `channel = "1.96.0"` + `rustfmt`/`clippy` (`profile = "minimal"`). rustup honours it **locally and in CI**, auto-installing the pinned toolchain + components on first `cargo` use — so contributors get byte-for-byte the same fmt/clippy as CI without thinking about it. Verified: `rustup show` reports `1.96.0 ... (overridden by rust-toolchain.toml)`.
- Pinned all **17** `dtolnay/rust-toolchain@stable` refs → `@1.96.0` across `build.yml`, `release.yml`, `security.yml`, `test-binaries.yml`, `test.yml` (no floating `stable` in CI).
- **CONTRIBUTING.md**: documented the bump process — update the toml `channel` + the workflow refs together in one reviewed PR (with a sed one-liner), so any resulting fmt/clippy changes land deliberately.

## Acceptance criteria
- [x] `rust-toolchain.toml` pins toolchain + rustfmt/clippy components
- [x] CI uses the pinned version (no floating `stable`)
- [x] Documented bump process

## Verification
- `rustup` override active (1.96.0); `cargo fmt --all -- --check` clean; `actionlint` shows no new errors from the version change.

## Observed, out of scope (follow-up candidate)
`actionlint` flags `release.yml`'s `softprops/action-gh-release@v1` as "too old to run on GitHub Actions" (deprecated Node16). Pre-existing, unrelated to the toolchain pin — worth a small follow-up to bump it to `@v2`.