### PR TITLE
Back-fill legacy daily/monthly aggregates into SQLite on migration (#52)

### DIFF
--- a/src/database/daily.rs
+++ b/src/database/daily.rs
@@ -61,6 +61,34 @@ impl SqliteDatabase {
         ))
     }
 
+    /// Import legacy daily aggregates from a JSON-to-SQLite migration (#52).
+    ///
+    /// Initial import only (`INSERT OR IGNORE`), mirroring `import_sessions`. Token columns
+    /// are left at their defaults (0) — a legacy `stats.json` carried no per-day token data.
+    /// `session_count` is derived from the number of session IDs the daily entry recorded.
+    pub fn import_daily(
+        &self,
+        daily: &std::collections::HashMap<String, crate::stats::DailyStats>,
+    ) -> Result<()> {
+        let mut conn = self.get_connection()?;
+        let tx = conn.transaction()?;
+        for (date, stats) in daily.iter() {
+            tx.execute(
+                "INSERT OR IGNORE INTO daily_stats (date, total_cost, total_lines_added, total_lines_removed, session_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    date,
+                    stats.total_cost,
+                    stats.lines_added as i64,
+                    stats.lines_removed as i64,
+                    stats.sessions.len() as i64,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Get all daily stats from the database
     pub fn get_all_daily_stats(
         &self,

--- a/src/database/monthly.rs
+++ b/src/database/monthly.rs
@@ -3,6 +3,33 @@ use crate::common::current_month;
 use rusqlite::{params, Result};
 
 impl SqliteDatabase {
+    /// Import legacy monthly aggregates from a JSON-to-SQLite migration (#52).
+    ///
+    /// Initial import only (`INSERT OR IGNORE`), mirroring `import_sessions`/`import_daily`.
+    /// Token columns default to 0 (legacy `stats.json` carried no monthly token data).
+    pub fn import_monthly(
+        &self,
+        monthly: &std::collections::HashMap<String, crate::stats::MonthlyStats>,
+    ) -> Result<()> {
+        let mut conn = self.get_connection()?;
+        let tx = conn.transaction()?;
+        for (month, stats) in monthly.iter() {
+            tx.execute(
+                "INSERT OR IGNORE INTO monthly_stats (month, total_cost, total_lines_added, total_lines_removed, session_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    month,
+                    stats.total_cost,
+                    stats.lines_added as i64,
+                    stats.lines_removed as i64,
+                    stats.sessions as i64,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Check if a session was active in a given month
     /// Returns true if the session exists and was last updated in the specified month (YYYY-MM format)
     /// Uses 'localtime' modifier to ensure timezone consistency with Rust's Local::now()

--- a/src/stats/persistence.rs
+++ b/src/stats/persistence.rs
@@ -122,11 +122,16 @@ impl StatsData {
                 "Migrating {} sessions from JSON to SQLite",
                 data.sessions.len()
             );
-            // Perform migration
+            // Perform migration. Back-fill the legacy daily/monthly aggregate maps too
+            // (#52) so historical rollups survive the upgrade — not just per-session rows.
             db.import_sessions(&data.sessions)?;
+            db.import_daily(&data.daily)?;
+            db.import_monthly(&data.monthly)?;
             log::info!(
-                "Successfully migrated {} sessions to SQLite",
-                data.sessions.len()
+                "Successfully migrated {} sessions, {} daily and {} monthly aggregates to SQLite",
+                data.sessions.len(),
+                data.daily.len(),
+                data.monthly.len()
             );
         } else {
             log::debug!("Skipping migration - database already has sessions");

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -944,10 +944,10 @@ fn test_burn_rate_config_min_duration_serde_default() {
 ///       (via `db.get_all_sessions()`), proving data survived rather than just that a
 ///       db file appeared.
 ///
-/// Daily/monthly note: `import_sessions` (database/session.rs:679) imports ONLY the
-/// `sessions` map — it does NOT copy the JSON `daily`/`monthly` maps. This test asserts
-/// what the code ACTUALLY does (session-level survival) and records the daily/monthly
-/// finding in the issue SUMMARY rather than asserting an aspirational behavior.
+/// Daily/monthly: as of #52 the migration also back-fills the legacy `daily`/`monthly`
+/// aggregate maps (via `import_daily`/`import_monthly`) so historical rollups survive the
+/// upgrade. This test asserts both the per-session survival AND the daily/monthly aggregates
+/// are migrated present-and-correct.
 #[test]
 #[serial]
 fn test_update_stats_data_migrates_legacy_json_when_db_missing() {
@@ -1046,24 +1046,42 @@ fn test_update_stats_data_migrates_legacy_json_when_db_missing() {
         "fallback must not return an empty default (that is the BREAK-03 bug)"
     );
 
-    // FINDING (recorded in SUMMARY): import_sessions migrates ONLY the sessions map.
-    // The JSON daily/monthly maps are NOT copied into daily_stats/monthly_stats by the
-    // migration path. Assert the ACTUAL behavior: no daily/monthly rows are produced
-    // purely by importing sessions (a no-op update does not write the current day either,
-    // since the updater added no cost). Session-level survival is the data-integrity
-    // guarantee this test pins.
+    // (#52) The migration now back-fills the legacy daily/monthly aggregate maps too —
+    // historical rollups survive the upgrade, not just per-session rows. Assert they are
+    // PRESENT and CORRECT in SQLite.
     let daily = db.get_all_daily_stats().unwrap();
     let monthly = db.get_all_monthly_stats().unwrap();
-    assert!(
-        !daily.contains_key("2025-01-01") && !daily.contains_key("2025-01-02"),
-        "DOCUMENTED: import_sessions does not migrate the JSON daily map (got: {:?})",
-        daily.keys().collect::<Vec<_>>()
+
+    let d1 = daily
+        .get("2025-01-01")
+        .expect("daily 2025-01-01 must migrate (#52)");
+    assert_eq!(d1.total_cost, 12.50, "daily 2025-01-01 cost must migrate");
+    assert_eq!(
+        d1.lines_added, 100,
+        "daily 2025-01-01 lines_added must migrate"
     );
-    assert!(
-        !monthly.contains_key("2025-01"),
-        "DOCUMENTED: import_sessions does not migrate the JSON monthly map (got: {:?})",
-        monthly.keys().collect::<Vec<_>>()
+    assert_eq!(
+        d1.lines_removed, 40,
+        "daily 2025-01-01 lines_removed must migrate"
     );
+    let d2 = daily
+        .get("2025-01-02")
+        .expect("daily 2025-01-02 must migrate (#52)");
+    assert_eq!(d2.total_cost, 7.25, "daily 2025-01-02 cost must migrate");
+
+    let m = monthly
+        .get("2025-01")
+        .expect("monthly 2025-01 must migrate (#52)");
+    assert_eq!(m.total_cost, 19.75, "monthly 2025-01 cost must migrate");
+    assert_eq!(
+        m.lines_added, 133,
+        "monthly 2025-01 lines_added must migrate"
+    );
+    assert_eq!(
+        m.lines_removed, 51,
+        "monthly 2025-01 lines_removed must migrate"
+    );
+    assert_eq!(m.sessions, 2, "monthly 2025-01 session_count must migrate");
 
     env::remove_var("XDG_DATA_HOME");
     env::remove_var("XDG_CONFIG_HOME");


### PR DESCRIPTION
Closes #52. Implements the **back-fill** option (chosen over document-only).

## Problem
On a v2.x→v3.0 upgrade, `migrate_to_sqlite` imported only the `sessions` map (via `import_sessions`), so a legacy `stats.json`'s `daily`/`monthly` aggregate totals were silently dropped — per-session history survived, but historical rollups did not. (Surfaced + pinned by the #38 test.)

## Fix
- Added non-feature-gated `SqliteDatabase::import_daily` (`database/daily.rs`) and `import_monthly` (`database/monthly.rs`) — `INSERT OR IGNORE`, mirroring `import_sessions`. `session_count` is derived from the entry's session list/count; token columns default to 0 (legacy JSON carried no token data). *(The existing `upsert_*_direct` helpers are `turso-sync`-gated and can't be used on the default-build migration path, hence new methods.)*
- `migrate_to_sqlite` now calls `import_daily` + `import_monthly` alongside `import_sessions` inside the `if !has_sessions` block.
- **Flipped the #38 regression test** to assert the daily/monthly aggregates are now present and correct in SQLite after migration (it previously pinned the drop behavior); updated its doc comment.

## Note
The migration gate is `!has_sessions`, so users who *already* migrated under the old code (sessions present, JSON since archived) won't retroactively back-fill. Acceptable — the fix targets fresh upgrades.

## Verification
- Diff confined to `daily.rs`, `monthly.rs`, `persistence.rs`, `stats/tests.rs`.
- Build (default **and** `--features turso-sync`), `cargo clippy -D warnings`, `cargo fmt --check`: all clean.
- Migration test 3× deterministic; full suite **1085/0** (default), **1097/0** (turso-sync).