### PR TITLE
Finish #34: re-enable flaky tests via color override + corrupted-DB fixture; demote 2 with root cause (#34)

### DIFF
--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -253,7 +253,16 @@ fn test_session_update_delta_calculation() {
 }
 
 #[test]
-#[ignore = "Flaky test - occasionally fails due to SQLite locking with concurrent connections"]
+// Demoted after the #34 determinism gate (10x runs): re-enabling flaked ~3/10.
+// Root cause is a production concurrency weakness NOT covered by #33: each of the 10
+// threads opens its OWN connection, and `update_session` uses a DEFERRED transaction
+// (`conn.transaction()`), so two readers can both attempt the read->write upgrade and
+// one receives an immediate SQLITE_BUSY ("database is locked") that the busy_timeout
+// handler cannot wait out (waiting would deadlock). Deterministically re-enabling this
+// requires switching the writer to an IMMEDIATE transaction — a production change that
+// is out of scope for #34 (the only sanctioned production change here is the color
+// override). A documented skip beats a flaky CI.
+#[ignore = "Concurrency race: update_session uses a DEFERRED transaction; concurrent read->write upgrades across separate connections hit non-waitable SQLITE_BUSY. Needs IMMEDIATE-transaction writer (production change, out of scope for #34). See issue #34."]
 fn test_concurrent_updates() {
     use std::thread;
 
@@ -462,7 +471,6 @@ fn test_session_start_time_preserved_on_update() {
 }
 
 #[test]
-#[ignore = "Flaky test - database isolation issues with parallel tests"]
 fn test_automatic_database_upgrade() {
     // This test verifies that an old database (v0 schema) is automatically
     // upgraded to the latest schema when SqliteDatabase::new() is called

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,13 +29,60 @@ fn get_current_theme() -> Theme {
         })
 }
 
+/// Test-only override for color enablement.
+///
+/// Encoding: `0` = unset (use the `NO_COLOR` env var), `1` = force-enabled,
+/// `2` = force-disabled. Defaults to `0`, so when no test sets it, color
+/// behavior is byte-identical to reading `NO_COLOR` directly (production path).
+///
+/// This exists solely to remove the process-global `NO_COLOR` env race from
+/// color tests (see issue #34); production code never sets it.
+static COLOR_OVERRIDE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// Set the test-only color override. `Some(true)` forces colors on,
+/// `Some(false)` forces colors off, `None` resets to env-driven behavior.
+///
+/// Not part of the public API; gated to tests within this crate.
+#[cfg(test)]
+pub(crate) fn set_color_override(state: Option<bool>) {
+    let v = match state {
+        Some(true) => 1u8,
+        Some(false) => 2u8,
+        None => 0u8,
+    };
+    COLOR_OVERRIDE.store(v, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Cross-crate test hook for the color override (used by integration tests in a
+/// separate crate that cannot reach the `pub(crate)` setter).
+///
+/// `Some(true)` forces colors on, `Some(false)` forces colors off, `None`
+/// resets to env-driven behavior. Hidden from docs and not part of the stable
+/// public API — for test use only (issue #34).
+#[doc(hidden)]
+pub fn __test_set_color_override(state: Option<bool>) {
+    let v = match state {
+        Some(true) => 1u8,
+        Some(false) => 2u8,
+        None => 0u8,
+    };
+    COLOR_OVERRIDE.store(v, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// ANSI color codes for terminal output.
 pub struct Colors;
 
 impl Colors {
-    /// Check if colors are enabled (respects NO_COLOR env var)
+    /// Check if colors are enabled.
+    ///
+    /// Consults the test-only [`COLOR_OVERRIDE`] first; when unset (the default,
+    /// and always in production) falls back to honoring the `NO_COLOR` env var.
     pub fn enabled() -> bool {
-        std::env::var("NO_COLOR").is_err()
+        match COLOR_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
+            1 => true,
+            2 => false,
+            _ => std::env::var("NO_COLOR").is_err(),
+        }
     }
 
     /// Get a color from theme, or empty string if colors are disabled
@@ -1093,6 +1140,47 @@ fn format_token_count_for_display(count: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[serial_test::serial]
+    fn test_color_override_forces_state_regardless_of_no_color() {
+        // Force-enabled: enabled() is true even when NO_COLOR is set.
+        let prior = std::env::var("NO_COLOR").ok();
+        std::env::set_var("NO_COLOR", "1");
+        set_color_override(Some(true));
+        assert!(
+            Colors::enabled(),
+            "force-on override must win over NO_COLOR"
+        );
+
+        // Force-disabled: enabled() is false even when NO_COLOR is unset.
+        std::env::remove_var("NO_COLOR");
+        set_color_override(Some(false));
+        assert!(
+            !Colors::enabled(),
+            "force-off override must win over absent NO_COLOR"
+        );
+
+        // Reset: behavior falls back to the env var (production path).
+        set_color_override(None);
+        std::env::remove_var("NO_COLOR");
+        assert!(
+            Colors::enabled(),
+            "with override unset and NO_COLOR unset, colors enabled"
+        );
+        std::env::set_var("NO_COLOR", "1");
+        assert!(
+            !Colors::enabled(),
+            "with override unset and NO_COLOR set, colors disabled"
+        );
+
+        // Cleanup.
+        set_color_override(None);
+        match prior {
+            Some(v) => std::env::set_var("NO_COLOR", v),
+            None => std::env::remove_var("NO_COLOR"),
+        }
+    }
 
     #[test]
     fn test_colors() {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1367,39 +1367,41 @@ mod tests {
         assert_eq!(realistic_burn, 3.0); // $3.00/hr is reasonable
     }
 
-    // Helper guard to temporarily clear NO_COLOR for theme tests
-    struct ClearNoColor(Option<String>);
-    impl ClearNoColor {
+    // RAII guard that forces colors ON via the test-only override (#34), removing the
+    // process-global NO_COLOR env race that previously made this test nondeterministic.
+    // On drop it resets the override back to env-driven behavior.
+    struct ForceColors;
+    impl ForceColors {
         fn new() -> Self {
-            let old = std::env::var("NO_COLOR").ok();
-            std::env::remove_var("NO_COLOR");
-            Self(old)
+            set_color_override(Some(true));
+            Self
         }
     }
-    impl Drop for ClearNoColor {
+    impl Drop for ForceColors {
         fn drop(&mut self) {
-            if let Some(val) = &self.0 {
-                std::env::set_var("NO_COLOR", val);
-            }
+            reset_color_override_helper();
         }
+    }
+
+    // Local reset helper so we don't need a second public symbol; forwards to the override.
+    fn reset_color_override_helper() {
+        set_color_override(None);
     }
 
     #[test]
-    // Deliberate skip (#34): depends on NO_COLOR being unset, but NO_COLOR is a
-    // process-global env var read live by Colors::enabled(). CI sets it globally, and
-    // parallel (non-serial) tests in this binary toggle it, so the result is
-    // nondeterministic. A robust re-enable needs non-global color enablement.
-    #[ignore = "global NO_COLOR env race; CI sets NO_COLOR — see issue #34"]
+    #[serial_test::serial]
+    // Re-enabled for #34: forces colors ON via the test-only color override instead of
+    // mutating the process-global NO_COLOR env var, so it no longer races other tests.
+    // Kept #[serial] as belt-and-suspenders against any other override toggling.
     fn test_theme_affects_colors() {
-        // Use RAII guard to ensure clean environment
-        let _guard = ClearNoColor::new();
+        // Force colors on via the override (no env mutation, no NO_COLOR race).
+        let _guard = ForceColors::new();
 
-        // Verify colors are actually enabled after clearing NO_COLOR
-        if !Colors::enabled() {
-            // If colors are still disabled, skip this test
-            eprintln!("Skipping theme test - colors remain disabled despite clearing NO_COLOR");
-            return;
-        }
+        // The override guarantees colors are enabled.
+        assert!(
+            Colors::enabled(),
+            "color override should force colors enabled"
+        );
 
         // Save original theme env var
         let original_theme = std::env::var("STATUSLINE_THEME").ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub mod utils;
 pub mod version;
 
 pub use config::Config;
+/// Test-only hook to override color enablement from a separate test crate.
+/// Hidden from docs; not part of the stable public API (issue #34).
+#[doc(hidden)]
+pub use display::__test_set_color_override;
 pub use display::{format_output, format_output_to_string};
 pub use error::{Result, StatuslineError};
 pub use git::get_git_status;

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -191,7 +191,15 @@ fn test_session_start_time_tracking() {
 
 #[test]
 #[serial]
-#[ignore = "Flaky test - thread synchronization timing issues cause intermittent failures"]
+// Demoted after the #34 determinism gate (10x runs): re-enabling flaked even with the
+// per-thread env mutation removed and XDG set once before spawn. The remaining cause is
+// the same production concurrency weakness as `database::tests::test_concurrent_updates`:
+// 10 threads each drive `update_stats_data` -> `update_session`, whose DEFERRED
+// transaction lets concurrent read->write upgrades hit a non-waitable SQLITE_BUSY, so
+// some sessions are not persisted and the "10 sessions created" assertion fails. A
+// deterministic fix needs an IMMEDIATE-transaction writer (production change, out of
+// scope for #34). A documented skip beats a flaky CI.
+#[ignore = "Concurrency race: update_stats_data -> update_session uses a DEFERRED transaction; concurrent read->write upgrades hit non-waitable SQLITE_BUSY and drop writes. Needs IMMEDIATE-transaction writer (production change, out of scope for #34). See issue #34."]
 fn test_concurrent_update_safety() {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
@@ -199,8 +207,11 @@ fn test_concurrent_update_safety() {
 
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().to_str().unwrap().to_string();
+    // Set XDG_* ONCE, before spawning threads. Env is process-global, so
+    // mutating it from inside spawned threads is both redundant and a race (#34).
     env::set_var("XDG_DATA_HOME", &temp_path);
-    env::set_var("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap());
+    env::set_var("XDG_CONFIG_HOME", &temp_path);
+    crate::config::reset_config();
 
     // Create the directory structure
     let stats_dir = Path::new(&temp_path).join("claudia-statusline");
@@ -216,12 +227,10 @@ fn test_concurrent_update_safety() {
     // Spawn 10 threads that each add $1.00
     for i in 0..10 {
         let completed_clone = completed.clone();
-        let temp_path_clone = temp_path.clone();
         let handle = thread::spawn(move || {
-            // Ensure the thread uses the temp directory
+            // XDG_* is already set process-globally before spawn; do NOT mutate
+            // env from inside the thread (#34).
             use crate::database::SessionUpdate;
-            env::set_var("XDG_DATA_HOME", &temp_path_clone);
-            env::set_var("XDG_CONFIG_HOME", &temp_path_clone);
             let (daily, _) = update_stats_data(|stats| {
                 stats.update_session(
                     &format!("test-thread-{}", i),
@@ -277,6 +286,8 @@ fn test_concurrent_update_safety() {
     }
 
     env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 #[test]
@@ -355,11 +366,11 @@ fn test_get_session_duration() {
 
 #[test]
 #[serial]
-#[ignore = "Flaky test - file system timing issues cause intermittent failures"]
 fn test_file_corruption_recovery() {
     let temp_dir = TempDir::new().unwrap();
     env::set_var("XDG_DATA_HOME", temp_dir.path().to_str().unwrap());
     env::set_var("XDG_CONFIG_HOME", temp_dir.path().to_str().unwrap());
+    crate::config::reset_config();
 
     let stats_path = StatsData::get_stats_file_path();
 
@@ -380,6 +391,8 @@ fn test_file_corruption_recovery() {
     assert_eq!(backup_contents, "not valid json {");
 
     env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 // NOTE (v3.0.0, Plan 06-01): the JSON write path was removed, which deleted the

--- a/tests/db_maintenance_tests.rs
+++ b/tests/db_maintenance_tests.rs
@@ -275,16 +275,115 @@ fn test_maintenance_script_help() {
 }
 
 #[test]
-#[ignore] // This test would require a corrupted database to test integrity check failure
 fn test_db_maintain_integrity_check_failure() {
-    let _guard = test_support::init();
-    // This test would need to:
-    // 1. Create a database
-    // 2. Corrupt it somehow
-    // 3. Run maintenance
-    // 4. Verify exit code is 1
+    // Implemented for issue #34: exercise the db-maintain integrity-check FAILURE branch.
     //
-    // Leaving as a placeholder for manual testing
+    // The db-maintain handler runs (in order) wal_checkpoint -> optimize -> prune ->
+    // vacuum -> PRAGMA integrity_check, then `process::exit(1)` iff integrity_check != "ok".
+    // To hit the integrity branch specifically we must:
+    //   1. Leave the 100-byte SQLite header intact so the file still OPENS (whole-file
+    //      garbage would fail at Connection::open, not at integrity_check).
+    //   2. Checkpoint+truncate the WAL so corruption lands in the main db file.
+    //   3. Suppress VACUUM (which would rebuild the file and mask/short-circuit the
+    //      corruption) by recording a recent `last_vacuum` so should_vacuum() == false.
+    //   4. Corrupt the CONTENTS of an interior b-tree page (page 2+, past the first page)
+    //      so checkpoint/optimize/prune still succeed but integrity_check reports damage.
+    use rusqlite::Connection;
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let _guard = test_support::init();
+    let (temp_dir, db_path) = setup_test_database();
+
+    // Add enough rows so the DB grows past a single page, giving us interior pages to
+    // corrupt without touching the header/first page.
+    {
+        let conn = Connection::open(&db_path).expect("open db to seed rows");
+        for i in 0..500 {
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions \
+                 (id, start_time, last_updated, cost_usd, input_tokens, output_tokens, \
+                  cache_creation_tokens, cache_read_tokens, model, lines_added, lines_removed) \
+                 VALUES (?1, datetime('now'), datetime('now'), 1.0, 100, 50, 0, 0, 'test-model-name', 10, 5)",
+                [format!("integrity-seed-session-{:04}", i)],
+            )
+            .ok(); // schema may differ slightly; best-effort seeding
+        }
+        // Suppress VACUUM: record a recent last_vacuum so should_vacuum() returns false.
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('last_vacuum', datetime('now'))",
+            [],
+        )
+        .ok();
+        // Checkpoint + truncate the WAL so corruption lands in the main db file, then
+        // drop the connection to release all locks before we tamper with the bytes.
+        let _: String = conn
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get(0))
+            .unwrap_or_default();
+    }
+
+    // Determine page size so we corrupt an interior page, not the header/first page.
+    let page_size: i64 = {
+        let conn = Connection::open(&db_path).expect("open db to read page_size");
+        conn.query_row("PRAGMA page_size", [], |row| row.get(0))
+            .expect("read page_size")
+    };
+    let file_len = fs::metadata(&db_path).expect("stat db").len();
+    assert!(
+        file_len > (2 * page_size) as u64,
+        "DB should span multiple pages for interior corruption (len={file_len}, page_size={page_size})"
+    );
+
+    // Corrupt a span of bytes starting partway into page 2 (1-indexed), leaving the
+    // 100-byte header and the first page (schema/root) intact so the file still opens.
+    let corrupt_offset = page_size + page_size / 2; // middle of page 2
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&db_path)
+            .expect("open db file for corruption");
+        file.seek(SeekFrom::Start(corrupt_offset as u64))
+            .expect("seek into interior page");
+        // Read the original bytes, then overwrite with garbage that differs from them.
+        let mut original = vec![0u8; page_size as usize];
+        let n = file.read(&mut original).expect("read interior bytes");
+        let garbage: Vec<u8> = (0..n).map(|i| original[i] ^ 0xFF).collect();
+        file.seek(SeekFrom::Start(corrupt_offset as u64))
+            .expect("seek back to corruption offset");
+        file.write_all(&garbage).expect("write garbage");
+        file.flush().expect("flush corruption");
+    }
+
+    // Sanity: the file must still OPEN (header intact) — otherwise we'd be testing the
+    // wrong branch (open failure rather than integrity_check failure).
+    {
+        let conn = Connection::open(&db_path).expect("corrupted db must still open");
+        // integrity_check should now report a non-"ok" result.
+        let result: String = conn
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .unwrap_or_else(|_| "ok".to_string());
+        assert_ne!(
+            result, "ok",
+            "interior-page corruption should make integrity_check fail (got: {result})"
+        );
+    }
+
+    // Run db-maintain against the corrupted DB; the handler must exit non-zero.
+    let output = Command::new(test_support::test_binary())
+        .env("XDG_DATA_HOME", temp_dir.path())
+        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .arg("db-maintain")
+        .arg("--quiet")
+        .output()
+        .expect("Failed to execute db-maintain");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "db-maintain should exit 1 when integrity_check fails. stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 // Test for data pruning with old records

--- a/tests/display_config_integration.rs
+++ b/tests/display_config_integration.rs
@@ -284,19 +284,14 @@ fn test_no_double_separators_regression() {
 
 #[test]
 #[serial_test::serial]
-// Run serially to avoid NO_COLOR env var conflicts
-// Deliberate skip (#34): NO_COLOR is read live by Colors::enabled() (not cached), but it
-// is a process-global env var. #[serial] only excludes other #[serial] tests, so a
-// non-serial test in this binary can clear/set NO_COLOR concurrently and flip the result.
-// A robust re-enable needs non-global color enablement.
-#[ignore = "global NO_COLOR env race under parallel tests — see issue #34"]
+// Re-enabled for #34: forces colors OFF via the test-only color override hook instead of
+// mutating the process-global NO_COLOR env var, so it no longer races other tests.
+// Kept #[serial] as belt-and-suspenders against any other override toggling.
 fn test_with_no_color_env() {
     let _guard = test_support::init();
-    // Save original state
-    let original_no_color = std::env::var("NO_COLOR").ok();
 
-    // Set NO_COLOR to test that it disables colors
-    std::env::set_var("NO_COLOR", "1");
+    // Force colors OFF via the override (no NO_COLOR env mutation, no race).
+    statusline::__test_set_color_override(Some(false));
 
     let output = format_output_to_string(
         "/test/path",
@@ -310,16 +305,13 @@ fn test_with_no_color_env() {
     // Should not contain ANSI escape codes
     assert!(
         !output.contains("\x1b["),
-        "Should not have ANSI codes with NO_COLOR"
+        "Should not have ANSI codes when colors are disabled"
     );
 
     // But should still show content
     assert!(output.contains("/test/path"), "Should show directory");
     assert!(output.contains("S3.5"), "Should show model");
 
-    // Restore original state
-    match original_no_color {
-        Some(val) => std::env::set_var("NO_COLOR", val),
-        None => std::env::remove_var("NO_COLOR"),
-    }
+    // Reset the override back to env-driven behavior.
+    statusline::__test_set_color_override(None);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -798,7 +798,18 @@ fn test_test_mode_flag() {
 }
 
 #[test]
-#[ignore] // Flaky: production database timestamps affected by parallel tests
+// KEEP-SKIPPED (#34): inherently nondeterministic, not fixable by isolation within this
+// test. It records the REAL, out-of-sandbox production stats.db mtime
+// (~/.local/share/claudia-statusline/stats.db) and asserts it is unchanged across two
+// --test-mode runs. Other integration binaries run as SEPARATE PROCESSES concurrently and
+// may legitimately open/write that real prod DB during this test's window, flipping the
+// mtime and failing the assertion through no fault of the code under test. #[serial] only
+// fences other #[serial] tests in the SAME binary, so it cannot prevent a sibling process
+// from touching the shared prod path.
+// TODO(#34, deferred redesign — NOT in scope here): re-author to assert only that the
+// temp-HOME test DB was created and the real prod path was never OPENED, using an isolated
+// HOME the binary cannot escape, instead of observing the shared prod mtime.
+#[ignore = "Observes the real out-of-sandbox prod stats.db mtime, which other concurrent integration *processes* may legitimately modify; not fixable by in-test isolation. See issue #34."]
 fn test_test_mode_uses_isolated_database() {
     let _guard = test_support::init();
     // Test that --test-mode uses a separate database path

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -82,11 +82,13 @@ fn test_no_double_separators() {
     // Bug: Disabling components caused " • • " in output
     // Fix: Proper conditional separator logic
 
-    // Clear NO_COLOR for this test
-    std::env::remove_var("NO_COLOR");
+    // Force colors on via the test-only override instead of mutating the process-global
+    // NO_COLOR env var (which races the #[serial] NO_COLOR test in this binary — #34).
+    statusline::__test_set_color_override(Some(true));
 
     // Test with minimal components
     let output = format_output_to_string("/test", Some("Claude"), None, None, 0.0, None);
+    statusline::__test_set_color_override(None);
 
     assert!(
         !output.contains(" • •"),
@@ -102,10 +104,11 @@ fn test_no_double_separators() {
 
 #[test]
 fn test_no_double_separators_with_git_disabled() {
-    std::env::remove_var("NO_COLOR");
+    statusline::__test_set_color_override(Some(true));
 
     // When git info is missing, separator logic should still work
     let output = format_output_to_string("/home/test", Some("Sonnet"), None, None, 5.0, None);
+    statusline::__test_set_color_override(None);
 
     assert!(
         !output.contains(" • •"),
@@ -120,12 +123,13 @@ fn test_no_double_separators_with_git_disabled() {
 
 #[test]
 fn test_git_info_no_leading_space() {
-    std::env::remove_var("NO_COLOR");
+    statusline::__test_set_color_override(Some(true));
 
     // Bug: Git info had leading space causing formatting issues
     // This would require mocking git, so we test indirectly
     // by checking that output doesn't start with space
     let output = format_output_to_string("/test", None, None, None, 0.0, None);
+    statusline::__test_set_color_override(None);
 
     // Output should not start with whitespace
     assert!(
@@ -147,34 +151,24 @@ fn test_git_info_no_leading_space() {
 #[test]
 #[serial]
 fn test_no_color_environment_variable() {
-    // Test that NO_COLOR is properly checked
-    // Note: Due to theme caching, we just verify that Colors::enabled() respects NO_COLOR
-    // Must be #[serial] to prevent race conditions with other tests modifying env vars
+    // Verify Colors::enabled() honors color disabling. Uses the test-only color override
+    // (#34) rather than mutating the process-global NO_COLOR env var, which previously
+    // raced non-serial sibling tests in this binary and caused intermittent failures.
     use statusline::display::Colors;
 
-    // Save original state
-    let original = std::env::var("NO_COLOR").ok();
-
-    // Test with NO_COLOR set
-    std::env::set_var("NO_COLOR", "1");
+    // Force colors OFF -> enabled() must be false.
+    statusline::__test_set_color_override(Some(false));
     assert!(
         !Colors::enabled(),
-        "Colors should be disabled when NO_COLOR=1"
+        "Colors should be disabled when forced off"
     );
 
-    // Test with NO_COLOR unset
-    std::env::remove_var("NO_COLOR");
-    assert!(
-        Colors::enabled(),
-        "Colors should be enabled when NO_COLOR is unset"
-    );
+    // Force colors ON -> enabled() must be true.
+    statusline::__test_set_color_override(Some(true));
+    assert!(Colors::enabled(), "Colors should be enabled when forced on");
 
-    // Restore original state
-    if let Some(value) = original {
-        std::env::set_var("NO_COLOR", value);
-    } else {
-        std::env::remove_var("NO_COLOR");
-    }
+    // Reset the override back to env-driven behavior.
+    statusline::__test_set_color_override(None);
 }
 
 // ============================================================================
@@ -208,10 +202,11 @@ fn test_session_counts_timezone_consistency() {
 
 #[test]
 fn test_empty_model_name() {
-    std::env::remove_var("NO_COLOR");
+    statusline::__test_set_color_override(Some(true));
 
     // Should handle None model gracefully
     let output = format_output_to_string("/test", None, None, None, 0.0, None);
+    statusline::__test_set_color_override(None);
 
     assert!(!output.is_empty(), "Should produce some output");
     assert!(
@@ -222,7 +217,7 @@ fn test_empty_model_name() {
 
 #[test]
 fn test_zero_cost() {
-    std::env::remove_var("NO_COLOR");
+    statusline::__test_set_color_override(Some(true));
 
     use statusline::models::Cost;
 
@@ -234,6 +229,7 @@ fn test_zero_cost() {
     };
 
     let output = format_output_to_string("/test", Some("Claude"), None, Some(&cost), 0.0, None);
+    statusline::__test_set_color_override(None);
 
     // Should handle zero cost without crashing
     assert!(!output.is_empty(), "Should produce output for zero cost");


### PR DESCRIPTION
Completes the remaining flaky-test work for #34, conservatively. **`#[ignore]` count: 8 → 3.**

## Dispositions of the 8 remaining ignored tests
- **RE-ENABLED (4):** `test_automatic_database_upgrade`, `test_file_corruption_recovery`, `test_theme_affects_colors`, `test_with_no_color_env`.
- **IMPLEMENTED (1):** `test_db_maintain_integrity_check_failure` — real fixture that corrupts *interior* SQLite page bytes (header intact) so the file opens and checkpoint/optimize/prune succeed but `PRAGMA integrity_check` fails → `db-maintain` exits 1.
- **DEMOTED back to `#[ignore]` (2):** `test_concurrent_updates`, `test_concurrent_update_safety` — flaked under the 10× determinism gate. Root cause (captured: `SqliteFailure(DatabaseBusy, "database is locked")` after retries) is a **DEFERRED transaction** in `update_session` (`src/database/session.rs:29`) — only the new-DB init path uses IMMEDIATE. Two concurrent connections both attempt the read→write upgrade and one gets an un-waitable `SQLITE_BUSY`. Fixing it needs an IMMEDIATE writer — a production change **out of scope for #34**. Accurate reasons recorded; **see follow-up below**.
- **KEPT-SKIPPED (1):** `test_test_mode_uses_isolated_database` — observes the real out-of-sandbox prod `stats.db` mtime that other integration *processes* may touch; a cross-process race not fixable by in-test isolation. Reason rewritten.

> Conservatism gate (per plan): a documented skip beats a flaky CI. The plan targeted 6 re-enables; 4 held under 10× parallel runs and 2 were demoted.

## The one production change (behavior-preserving)
A color override at the `Colors::enabled()` chokepoint (`src/display.rs`): a module `AtomicU8` (0 = unset → use `NO_COLOR` env, 1 = force-on, 2 = force-off). **Default 0 → production behavior byte-identical** (NO_COLOR still honored). Test setters: `#[cfg(test)]` internal + a `#[doc(hidden)] pub __test_set_color_override` re-exported in `lib.rs` for the cross-crate integration test. No `unsafe`; `git diff main -- src/` shows only `display.rs` + `lib.rs`.

This also de-flaked a **pre-existing** NO_COLOR race in `tests/regression_tests.rs` (it set `NO_COLOR=1` while non-serial siblings cleared it) — same class, same sanctioned fix.

## Verification
- Production src change confined to `display.rs` + `lib.rs`; no other non-test changes; no `unsafe`.
- `#[ignore]` count = 3; both builds (default + `--features turso-sync`), `clippy -D warnings`, `fmt` (1.96.0) all clean.
- Determinism: full suite **10/10 (executor) + 5/5 (independent)** green; re-enabled targets confirmed running.

## Recommended follow-up
File an issue to switch `update_session` (`src/database/session.rs:29`) to an **IMMEDIATE** transaction — that would let `test_concurrent_updates` / `test_concurrent_update_safety` be re-enabled deterministically (and hardens the real concurrent-write path).