### PR TITLE
Use IMMEDIATE transaction in update_session; re-enable concurrency tests (#57)

### DIFF
--- a/src/database/session.rs
+++ b/src/database/session.rs
@@ -23,10 +23,17 @@ impl SqliteDatabase {
     pub fn update_session(&self, session_id: &str, update: SessionUpdate) -> Result<(f64, f64)> {
         let retry_config = RetryConfig::for_db_ops();
 
-        // Wrap the entire transaction in retry logic
+        // Wrap the entire transaction in retry logic.
+        //
+        // IMMEDIATE (not the default DEFERRED): update_session_tx reads then writes, so a
+        // DEFERRED transaction starts as a reader and upgrades to a writer mid-transaction.
+        // Under concurrent writers (multiple processes/connections) two such read->write
+        // upgrades hit an immediate SQLITE_BUSY that busy_timeout cannot wait out, dropping a
+        // write (issue #57). IMMEDIATE takes the write lock at BEGIN so concurrent writers
+        // serialize there and retry_if_retryable absorbs the contention cleanly.
         retry_if_retryable(&retry_config, || {
             let mut conn = self.get_connection()?;
-            let tx = conn.transaction()?;
+            let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
             let result = self.update_session_tx(&tx, session_id, update.clone())?;
 

--- a/src/database/tests.rs
+++ b/src/database/tests.rs
@@ -253,16 +253,12 @@ fn test_session_update_delta_calculation() {
 }
 
 #[test]
-// Demoted after the #34 determinism gate (10x runs): re-enabling flaked ~3/10.
-// Root cause is a production concurrency weakness NOT covered by #33: each of the 10
-// threads opens its OWN connection, and `update_session` uses a DEFERRED transaction
-// (`conn.transaction()`), so two readers can both attempt the read->write upgrade and
-// one receives an immediate SQLITE_BUSY ("database is locked") that the busy_timeout
-// handler cannot wait out (waiting would deadlock). Deterministically re-enabling this
-// requires switching the writer to an IMMEDIATE transaction — a production change that
-// is out of scope for #34 (the only sanctioned production change here is the color
-// override). A documented skip beats a flaky CI.
-#[ignore = "Concurrency race: update_session uses a DEFERRED transaction; concurrent read->write upgrades across separate connections hit non-waitable SQLITE_BUSY. Needs IMMEDIATE-transaction writer (production change, out of scope for #34). See issue #34."]
+#[serial_test::serial]
+// Re-enabled by #57: update_session now uses an IMMEDIATE transaction, so concurrent
+// read->write upgrades across separate connections serialize at BEGIN and
+// retry_if_retryable absorbs contention instead of dropping writes. Marked #[serial]
+// so this 10-thread DB-stress test doesn't add parallel I/O pressure that destabilizes
+// other tests' isolation (it does not mutate global env itself).
 fn test_concurrent_updates() {
     use std::thread;
 

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -22,8 +22,19 @@ fn test_stats_data_default() {
 }
 
 #[test]
+#[serial]
 fn test_stats_data_update_session() {
     use crate::database::SessionUpdate;
+
+    // Isolate: StatsData::update_session writes through to SQLite at the ambient
+    // get_data_dir(), so without a temp XDG this test pollutes the real user DB AND can
+    // drop a stats.db into a concurrently-running test's temp dir (it raced
+    // test_backup_file_permissions). Pin XDG to a temp dir + reset_config; #[serial].
+    let temp_dir = TempDir::new().unwrap();
+    env::set_var("XDG_DATA_HOME", temp_dir.path());
+    env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+    crate::config::reset_config();
+
     let mut stats = StatsData::default();
     let (daily, monthly) = stats.update_session(
         "test-session",
@@ -45,6 +56,10 @@ fn test_stats_data_update_session() {
     assert_eq!(monthly, 10.0);
     assert_eq!(stats.all_time.total_cost, 10.0);
     assert_eq!(stats.all_time.sessions, 1);
+
+    env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 #[test]
@@ -191,15 +206,9 @@ fn test_session_start_time_tracking() {
 
 #[test]
 #[serial]
-// Demoted after the #34 determinism gate (10x runs): re-enabling flaked even with the
-// per-thread env mutation removed and XDG set once before spawn. The remaining cause is
-// the same production concurrency weakness as `database::tests::test_concurrent_updates`:
-// 10 threads each drive `update_stats_data` -> `update_session`, whose DEFERRED
-// transaction lets concurrent read->write upgrades hit a non-waitable SQLITE_BUSY, so
-// some sessions are not persisted and the "10 sessions created" assertion fails. A
-// deterministic fix needs an IMMEDIATE-transaction writer (production change, out of
-// scope for #34). A documented skip beats a flaky CI.
-#[ignore = "Concurrency race: update_stats_data -> update_session uses a DEFERRED transaction; concurrent read->write upgrades hit non-waitable SQLITE_BUSY and drop writes. Needs IMMEDIATE-transaction writer (production change, out of scope for #34). See issue #34."]
+// Re-enabled by #57: update_session now uses an IMMEDIATE transaction, so the 10 threads
+// driving update_stats_data -> update_session serialize their writes at BEGIN (with
+// retry_if_retryable) instead of dropping some via a non-waitable SQLITE_BUSY.
 fn test_concurrent_update_safety() {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;


### PR DESCRIPTION
Closes #57.

## Fix
`SqliteDatabase::update_session` opened a **DEFERRED** transaction (it reads then writes), so under concurrent writers across separate connections two read→write upgrades hit an immediate `SQLITE_BUSY` that `busy_timeout` can't wait out — dropping a write. Switched it to an **IMMEDIATE** transaction (`transaction_with_behavior(Immediate)`) so writers serialize at BEGIN and the existing `retry_if_retryable` wrapper absorbs contention (mirrors the new-DB init path). #33 fixed the concurrent *migration* race; this fixes the steady-state *writer* race.

## Tests
- **Re-enabled** `test_concurrent_updates` (database) and `test_concurrent_update_safety` (stats) — both now **deterministic (16/16 targeted runs)**. `#[ignore]` count **3 → 1**.
- Marked the 10-thread `test_concurrent_updates` `#[serial]` so it doesn't add parallel I/O pressure.
- **Isolated `test_stats_data_update_session`** (temp XDG + `reset_config` + `#[serial]`): it called `StatsData::update_session`, which writes through to the **ambient** `get_data_dir()` — polluting the real user DB and racing the serial recovery tests. (A genuine pre-existing isolation bug, fixed here.)

## Verification
- Build (default **and** `--features turso-sync`), `clippy -D warnings`, `fmt` (1.96.0): all clean.
- Diff confined to `session.rs`, `database/tests.rs`, `stats/tests.rs`.
- The 2 target tests: **16/16** green.

## Known follow-up (separate, pre-existing, local-only)
A recovery test (`test_file_corruption_recovery`) can still flake **~1/10 locally** because it (and `test_backup_file_permissions`) depend on `load_from_sqlite()` failing, which breaks if a real `~/.local/share/claudia-statusline/stats.db` exists and a concurrent test's ambient write lands in its temp dir. **CI is unaffected** (fresh runners have no real DB). This is a deeper test-isolation issue beyond #57's scope — filing a follow-up to make the recovery tests immune to ambient DB state.