### PR TITLE
Bump softprops/action-gh-release v1 → v2 in release.yml (#58)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,7 @@ jobs:
           ls -la *.tar.gz *.zip *.sha256 || true
 
       - name: Create Release with Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Closes #58.

`softprops/action-gh-release@v1` runs on the deprecated **Node16** runtime — `actionlint` flagged it as "too old to run on GitHub Actions", and GitHub is sunsetting Node16 actions, so the **tag-triggered** release workflow could fail on a future runner image (and wouldn't surface until a release is cut).

Bumped to **`@v2`** (Node20). The step's inputs (`token`, `tag_name`, `name`, `files`, `body`) are unchanged and v2 is a drop-in for them. Validated locally with `actionlint` — the deprecated-action error is resolved. (release.yml is tag-triggered so it can't run on this PR; verified via actionlint.)