### PR TITLE
Make recovery tests immune to ambient global-DB races (#61)

### DIFF
--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -387,6 +387,14 @@ fn test_file_corruption_recovery() {
     fs::create_dir_all(stats_path.parent().unwrap()).unwrap();
     fs::write(&stats_path, "not valid json {").unwrap();
 
+    // (#61) Enforce this test's precondition — "no SQLite db present" — immediately before
+    // load(). While this #[serial] test holds the global XDG, a concurrent non-serial test
+    // that touches the global get_data_dir() can create a stats.db in this very temp dir,
+    // which would make load() return SQLite data and skip the corrupt-JSON backup path.
+    if let Ok(p) = StatsData::get_sqlite_path() {
+        let _ = fs::remove_file(&p);
+    }
+
     // Load should handle corruption gracefully
     let stats = StatsData::load();
     assert_eq!(stats.version, "1.0");
@@ -420,12 +428,21 @@ fn test_backup_file_permissions() {
 
     let temp_dir = TempDir::new().unwrap();
     env::set_var("XDG_DATA_HOME", temp_dir.path());
+    env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+    crate::config::reset_config();
 
     let stats_path = get_data_dir().join("stats.json");
 
     // Create corrupted stats file
     fs::create_dir_all(stats_path.parent().unwrap()).unwrap();
     fs::write(&stats_path, "not valid json {").unwrap();
+
+    // (#61) Enforce the "no SQLite db present" precondition right before load(): while this
+    // #[serial] test holds the global XDG, a concurrent non-serial test touching the global
+    // get_data_dir() can drop a stats.db here, making load() skip the corrupt-JSON backup.
+    if let Ok(p) = StatsData::get_sqlite_path() {
+        let _ = fs::remove_file(&p);
+    }
 
     // Load stats (triggers backup creation)
     let _stats = StatsData::load();
@@ -445,6 +462,8 @@ fn test_backup_file_permissions() {
     );
 
     env::remove_var("XDG_DATA_HOME");
+    env::remove_var("XDG_CONFIG_HOME");
+    crate::config::reset_config();
 }
 
 /// BREAK-03 positive recovery test: with NO stats.db present but a valid stats.json


### PR DESCRIPTION
Closes #61. Test-only; no production change.

## Root cause (diagnosed empirically)
`test_backup_file_permissions` and `test_file_corruption_recovery` rely on `load_from_sqlite()` **failing** (no db present) so `StatsData::load()` takes the corrupt-JSON **backup** path. Instrumenting the failing test showed: XDG was correctly the test's temp dir, yet a `stats.db` **existed** in it (the test only wrote `stats.json`). Mechanism: while these `#[serial]` tests hold the **global** `XDG_DATA_HOME`, a concurrent **non-serial** test that touches the global `get_data_dir()` (and `SqliteDatabase::new` *creates* the db) drops a `stats.db` into the recovery test's temp dir → `load()` returns SQLite data → backup skipped → assert fails.

**Local-only:** requires a real `~/.local/share/claudia-statusline/stats.db` (CI's fresh runners have none, so CI was always green — confirmed across the whole milestone).

## Fix
- Enforce the tests' actual precondition ("no SQLite db present") by deleting `get_sqlite_path()` **immediately before** `load()` — shrinking the race window from "everything after `set_var`" to the few instructions before `load_from_sqlite()`'s existence check (~1000× smaller).
- Fully isolate `test_backup_file_permissions` (it was missing `XDG_CONFIG_HOME` + `reset_config` + cleanup) to match the established convention.

## Verification
- **Full suite 20/20 green locally with a real `~/.local/share` DB present** (was ~1/10 before).
- `clippy -D warnings` + `fmt` clean. Diff is **test-only** (`src/stats/tests.rs`, +19 lines) — no production code touched.

## Note
This pragmatically eliminates the observed flake. The deeper architectural fix (no test ever touches the *global* data dir; dependency-inject the data path) is larger and out of scope — the precondition guard + isolation makes these tests robust in practice.